### PR TITLE
Add version flag. Closes thenativeweb/org#473

### DIFF
--- a/lib/bin/wolkenkit.js
+++ b/lib/bin/wolkenkit.js
@@ -28,7 +28,7 @@ const commands = require('../cli/commands'),
   }
 
   if (!parsed.command) {
-    if (parsed.argv.length === 1 && parsed.argv[0] === '--version') {
+    if (parsed.argv.length > 0 && parsed.argv.includes('--version')) {
       buntstift.info(packageJson.version);
       buntstift.exit(0);
     }

--- a/lib/bin/wolkenkit.js
+++ b/lib/bin/wolkenkit.js
@@ -10,7 +10,8 @@ const buntstift = require('buntstift'),
       findSuggestions = require('findsuggestions');
 
 const commands = require('../cli/commands'),
-      globalOptionDefinitions = require('../cli/globalOptionDefinitions');
+      globalOptionDefinitions = require('../cli/globalOptionDefinitions'),
+      packageJson = require('../../package.json');
 
 (async function () {
   const validCommands = Object.keys(commands);
@@ -27,6 +28,11 @@ const commands = require('../cli/commands'),
   }
 
   if (!parsed.command) {
+    if (parsed.argv.length === 1 && parsed.argv[0] === '--version') {
+      buntstift.info(packageJson.version);
+      buntstift.exit(0);
+    }
+
     parsed.command = 'help';
   }
 

--- a/test/stories/helpers/getWolkenkit.js
+++ b/test/stories/helpers/getWolkenkit.js
@@ -19,7 +19,7 @@ const getWolkenkit = async function (options) {
   const { ipAddress } = options;
 
   return async function (name, parameters = {}, opts = {}) {
-    if (!name) {
+    if (name === undefined) {
       throw new Error('Name is missing.');
     }
 

--- a/test/stories/setupTests.js
+++ b/test/stories/setupTests.js
@@ -62,10 +62,10 @@ const isolatedAsync = promisify(isolated);
     });
 
     await test('[wolkenkit --version] shows its version number.', async ({ directory }) => {
-      const { code, stdout, stderr } = await wolkenkit('', { version: true }, { cwd: directory });
+      const { code, stdout, stderr } = await wolkenkit('--version', {}, { cwd: directory });
 
-      assert.that(code).is.not.equalTo(0);
-      assert.that(stdout).is.equalTo(`  ${packageJson.version}`);
+      assert.that(code).is.equalTo(0);
+      assert.that(stdout).is.equalTo(`  ${packageJson.version}\n`);
       assert.that(stderr).is.equalTo('');
     });
 

--- a/test/stories/setupTests.js
+++ b/test/stories/setupTests.js
@@ -9,18 +9,25 @@ const assert = require('assertthat'),
 const getDirectoryList = require('./helpers/getDirectoryList'),
       suite = require('./helpers/suite');
 
-const defaults = require('../../lib/cli/defaults');
+const defaults = require('../../lib/cli/defaults'),
+      packageJson = require('../../package.json');
 
 const isolatedAsync = promisify(isolated);
 
 (async () => {
   await suite('setup', async ({ test, wolkenkit }) => {
-    await test('[wolkenkit] suggests a command when an unknown command is given.', async ({ directory }) => {
-      const { code, stdout, stderr } = await wolkenkit('hel', {}, { cwd: directory });
+    await test('[wolkenkit] shows the usage.', async ({ directory }) => {
+      const { code, stderr, stdout } = await wolkenkit('', {}, { cwd: directory });
 
-      assert.that(code).is.not.equalTo(0);
-      assert.that(stdout).is.equalTo('');
-      assert.that(stderr).is.equalTo('✗ Unknown command \'hel\', did you mean \'help\'?\n');
+      assert.that(code).is.equalTo(0);
+      assert.that(stdout).is.matching(/Verify whether wolkenkit is setup correctly/);
+      assert.that(stdout).is.matching(/Show the help/);
+      assert.that(stdout).is.matching(/Initialize a new application/);
+      assert.that(stdout).is.matching(/List installed wolkenkit versions/);
+      assert.that(stdout).is.matching(/List available wolkenkit versions/);
+      assert.that(stdout).is.matching(/Start an application/);
+      assert.that(stdout).is.matching(/Update the wolkenkit CLI/);
+      assert.that(stderr).is.equalTo('');
     });
 
     await test('[wolkenkit help] shows the usage.', async ({ directory }) => {
@@ -28,11 +35,11 @@ const isolatedAsync = promisify(isolated);
 
       assert.that(code).is.equalTo(0);
       assert.that(stdout).is.matching(/Verify whether wolkenkit is setup correctly/);
-      assert.that(stdout).is.matching(/Shows the help/);
-      assert.that(stdout).is.matching(/Initializes a new application/);
-      assert.that(stdout).is.matching(/Show installed wolkenkit versions/);
-      assert.that(stdout).is.matching(/Show available wolkenkit versions/);
-      assert.that(stdout).is.matching(/Starts an application/);
+      assert.that(stdout).is.matching(/Show the help/);
+      assert.that(stdout).is.matching(/Initialize a new application/);
+      assert.that(stdout).is.matching(/List installed wolkenkit versions/);
+      assert.that(stdout).is.matching(/List available wolkenkit versions/);
+      assert.that(stdout).is.matching(/Start an application/);
       assert.that(stdout).is.matching(/Update the wolkenkit CLI/);
       assert.that(stderr).is.equalTo('');
     });
@@ -41,8 +48,24 @@ const isolatedAsync = promisify(isolated);
       const { code, stderr, stdout } = await wolkenkit('init', { help: true }, { cwd: directory });
 
       assert.that(code).is.equalTo(0);
-      assert.that(stdout).is.matching(/Initializes a new application/);
+      assert.that(stdout).is.matching(/Initialize a new application/);
       assert.that(stdout).is.matching(/wolkenkit init \[--template <url>\]/);
+      assert.that(stderr).is.equalTo('');
+    });
+
+    await test('[wolkenkit] suggests a command when an unknown command is given.', async ({ directory }) => {
+      const { code, stdout, stderr } = await wolkenkit('hel', {}, { cwd: directory });
+
+      assert.that(code).is.not.equalTo(0);
+      assert.that(stdout).is.equalTo('');
+      assert.that(stderr).is.equalTo('✗ Unknown command \'hel\', did you mean \'help\'?\n');
+    });
+
+    await test('[wolkenkit --version] shows its version number.', async ({ directory }) => {
+      const { code, stdout, stderr } = await wolkenkit('', { version: true }, { cwd: directory });
+
+      assert.that(code).is.not.equalTo(0);
+      assert.that(stdout).is.equalTo(`  ${packageJson.version}`);
       assert.that(stderr).is.equalTo('');
     });
 


### PR DESCRIPTION
Hi @grundhoeferj!

I have added the missing `--version` flag, but I have not been able to run the AWS tests (because I was on train, and the wi-fi was quite unstable).

So, could you please have a look at my changes, and check whether the AWS tests work? If everything is fine, can you then please merge this PR? If not, can you please comment on what was not okay?

Thanks 😊 