### PR TITLE
Make node environment optional. Closes thenativeweb/org#478

### DIFF
--- a/configuration/1.0.0/broker/container.js
+++ b/configuration/1.0.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/broker/container.js
+++ b/configuration/1.0.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/broker/container.js
+++ b/configuration/1.0.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/core/container.js
+++ b/configuration/1.0.0/core/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.0/core/container.js
+++ b/configuration/1.0.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/core/container.js
+++ b/configuration/1.0.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/core/container.js
+++ b/configuration/1.0.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/depot-file/container.js
+++ b/configuration/1.0.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/depot-file/container.js
+++ b/configuration/1.0.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/depot-file/container.js
+++ b/configuration/1.0.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/flows/container.js
+++ b/configuration/1.0.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/flows/container.js
+++ b/configuration/1.0.0/flows/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.0/flows/container.js
+++ b/configuration/1.0.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/flows/container.js
+++ b/configuration/1.0.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.0/node-modules/container.js
+++ b/configuration/1.0.0/node-modules/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.0/node-modules/container.js
+++ b/configuration/1.0.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/node-modules/container.js
+++ b/configuration/1.0.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/node-modules/container.js
+++ b/configuration/1.0.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.0/schema.js
+++ b/configuration/1.0.0/schema.js
@@ -68,7 +68,7 @@ const schema = function () {
                 additionalProperties: false
               }
             },
-            required: [ 'api', 'node' ],
+            required: [ 'api' ],
             additionalProperties: false
           }
         },

--- a/configuration/1.0.1/broker/container.js
+++ b/configuration/1.0.1/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/broker/container.js
+++ b/configuration/1.0.1/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/broker/container.js
+++ b/configuration/1.0.1/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/core/container.js
+++ b/configuration/1.0.1/core/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.1/core/container.js
+++ b/configuration/1.0.1/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/core/container.js
+++ b/configuration/1.0.1/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/core/container.js
+++ b/configuration/1.0.1/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/depot-file/container.js
+++ b/configuration/1.0.1/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/depot-file/container.js
+++ b/configuration/1.0.1/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/depot-file/container.js
+++ b/configuration/1.0.1/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/flows/container.js
+++ b/configuration/1.0.1/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/flows/container.js
+++ b/configuration/1.0.1/flows/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.1/flows/container.js
+++ b/configuration/1.0.1/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/flows/container.js
+++ b/configuration/1.0.1/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.0.1/node-modules/container.js
+++ b/configuration/1.0.1/node-modules/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.0.1/node-modules/container.js
+++ b/configuration/1.0.1/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/node-modules/container.js
+++ b/configuration/1.0.1/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/node-modules/container.js
+++ b/configuration/1.0.1/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.0.1/schema.js
+++ b/configuration/1.0.1/schema.js
@@ -68,7 +68,7 @@ const schema = function () {
                 additionalProperties: false
               }
             },
-            required: [ 'api', 'node' ],
+            required: [ 'api' ],
             additionalProperties: false
           }
         },

--- a/configuration/1.1.0/broker/container.js
+++ b/configuration/1.1.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/broker/container.js
+++ b/configuration/1.1.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/broker/container.js
+++ b/configuration/1.1.0/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/core/container.js
+++ b/configuration/1.1.0/core/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.1.0/core/container.js
+++ b/configuration/1.1.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/core/container.js
+++ b/configuration/1.1.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/core/container.js
+++ b/configuration/1.1.0/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/depot-file/container.js
+++ b/configuration/1.1.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/depot-file/container.js
+++ b/configuration/1.1.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/depot-file/container.js
+++ b/configuration/1.1.0/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/flows/container.js
+++ b/configuration/1.1.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/flows/container.js
+++ b/configuration/1.1.0/flows/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.1.0/flows/container.js
+++ b/configuration/1.1.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/flows/container.js
+++ b/configuration/1.1.0/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/1.1.0/node-modules/container.js
+++ b/configuration/1.1.0/node-modules/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/1.1.0/node-modules/container.js
+++ b/configuration/1.1.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/node-modules/container.js
+++ b/configuration/1.1.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/node-modules/container.js
+++ b/configuration/1.1.0/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/1.1.0/schema.js
+++ b/configuration/1.1.0/schema.js
@@ -68,7 +68,7 @@ const schema = function () {
                 additionalProperties: false
               }
             },
-            required: [ 'api', 'node' ],
+            required: [ 'api' ],
             additionalProperties: false
           }
         },

--- a/configuration/latest/broker/container.js
+++ b/configuration/latest/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/broker/container.js
+++ b/configuration/latest/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/broker/container.js
+++ b/configuration/latest/broker/container.js
@@ -61,7 +61,7 @@ const container = function (options) {
         '/keys/wildcard.wolkenkit.io',
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       LISTSTORE_URL: `mongodb://wolkenkit:${sharedKey}@liststore:27017/wolkenkit`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/core/container.js
+++ b/configuration/latest/core/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/latest/core/container.js
+++ b/configuration/latest/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/core/container.js
+++ b/configuration/latest/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/core/container.js
+++ b/configuration/latest/core/container.js
@@ -45,7 +45,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/depot-file/container.js
+++ b/configuration/latest/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/depot-file/container.js
+++ b/configuration/latest/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/depot-file/container.js
+++ b/configuration/latest/depot-file/container.js
@@ -37,7 +37,7 @@ const container = function (options) {
       IDENTITYPROVIDER_CERTIFICATE: get(selectedEnvironment, 'identityProvider.certificate', '/keys/wildcard.wolkenkit.io'),
       IDENTITYPROVIDER_NAME: get(selectedEnvironment, 'identityProvider.name', 'auth.wolkenkit.io'),
       KEYS: get(selectedEnvironment, 'api.certificate', '/keys/local.wolkenkit.io'),
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/flows/container.js
+++ b/configuration/latest/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment,
+      NODE_ENV: selectedEnvironment.node.environment || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/flows/container.js
+++ b/configuration/latest/flows/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/latest/flows/container.js
+++ b/configuration/latest/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: selectedEnvironment.node.environment || 'development',
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/flows/container.js
+++ b/configuration/latest/flows/container.js
@@ -43,7 +43,7 @@ const container = function (options) {
       EVENTSTORE_TYPE: 'postgres',
       EVENTSTORE_URL: `pg://wolkenkit:${sharedKey}@eventstore:5432/wolkenkit`,
       FLOWBUS_URL: `amqp://wolkenkit:${sharedKey}@messagebus:5672`,
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development',
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development'),
       PROFILING_HOST: selectedEnvironment.api.address.host,
       PROFILING_PORT: 8125
     },

--- a/configuration/latest/node-modules/container.js
+++ b/configuration/latest/node-modules/container.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const get = require('lodash/get');
+
 const image = require('./image');
 
 const container = function (options) {

--- a/configuration/latest/node-modules/container.js
+++ b/configuration/latest/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment
+      NODE_ENV: selectedEnvironment.node.environment || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/node-modules/container.js
+++ b/configuration/latest/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: selectedEnvironment.node.environment || 'development'
+      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/node-modules/container.js
+++ b/configuration/latest/node-modules/container.js
@@ -32,7 +32,7 @@ const container = function (options) {
     image: `${configuration.application}-node-modules`,
     name: `${configuration.application}-node-modules`,
     env: {
-      NODE_ENV: (selectedEnvironment.node && selectedEnvironment.node.environment) || 'development'
+      NODE_ENV: get(selectedEnvironment, 'node.environment', 'development')
     },
     labels: {
       'wolkenkit-api-host': selectedEnvironment.api.address.host,

--- a/configuration/latest/schema.js
+++ b/configuration/latest/schema.js
@@ -68,7 +68,7 @@ const schema = function () {
                 additionalProperties: false
               }
             },
-            required: [ 'api', 'node' ],
+            required: [ 'api' ],
             additionalProperties: false
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wolkenkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13,7 +13,7 @@
     "acorn": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-      "integrity": "sha1-kRy1PgNoB88Pp3jcXTcPvYZCRtc="
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -75,7 +75,7 @@
     "ansi-escape-sequences": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha1-4OywQpWLceQpQtNcH88dmwCg9n4=",
+      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
       "requires": {
         "array-back": "2.0.0"
       }
@@ -83,7 +83,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I="
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
     },
     "ansi-red": {
       "version": "0.1.1",
@@ -102,7 +102,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
         "color-convert": "1.9.0"
       }
@@ -122,7 +122,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -156,7 +156,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -168,7 +168,7 @@
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "requires": {
         "typical": "2.6.1"
       }
@@ -249,7 +249,7 @@
     "assertthat": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/assertthat/-/assertthat-0.11.0.tgz",
-      "integrity": "sha1-wTHrIYG1ctuZSxCG8/wRz7/H0U8=",
+      "integrity": "sha512-x674Uww2rCI4uD3EHJ51I0ALsGUYeG583D1i/JHePjosnWh/r6deXLsr1+eY1/EGjfOKSlMU7E+nALxlyWWgtg==",
       "dev": true,
       "requires": {
         "comparejs": "0.1.6",
@@ -1056,7 +1056,7 @@
         "regenerator-runtime": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
+          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
         }
       }
     },
@@ -1105,7 +1105,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -1187,7 +1187,7 @@
     "bump-regex": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/bump-regex/-/bump-regex-2.8.0.tgz",
-      "integrity": "sha1-CObN/0f6rAuDqpqyF690PBc/yps=",
+      "integrity": "sha512-prjTDXzGEbTvCgDVEAKvOGpAqZnz5EmzJNiYi2L72TjNy+T91w3SbPgofnAsLXZZBqZigv+kN4oF5oEIyr6LPw==",
       "dev": true,
       "requires": {
         "semver": "5.4.1",
@@ -1197,7 +1197,7 @@
     "buntstift": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/buntstift/-/buntstift-0.5.0.tgz",
-      "integrity": "sha1-zbOAayO4m0O1dW5nVoYelYj9Sy8=",
+      "integrity": "sha512-TSfHlocGjOJG6jqz8cgpsYjaC50NOCbtqeOo1wnYixypu3SFReXEyH1N2NDp7wUh/dk39W7Weq4qm5RnOVGPhA==",
       "requires": {
         "chalk": "2.1.0",
         "node-spinner": "0.0.4"
@@ -1251,7 +1251,7 @@
     "certificate-details": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/certificate-details/-/certificate-details-0.3.0.tgz",
-      "integrity": "sha1-GkEVETNTcWGg3EB+GLTjhS4iizk=",
+      "integrity": "sha512-DjM80+Mc/b7CHkqdva4rQzhQBeyJLjzY+m93OoadoTmxPon6fddUR8nL7zXlQ2xh70xXga5JsO/2XE0QHwozfw==",
       "requires": {
         "freeport": "1.0.5"
       }
@@ -1259,7 +1259,7 @@
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
+      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -1292,7 +1292,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY="
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -1392,7 +1392,7 @@
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM=",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
       "dev": true
     },
     "color-convert": {
@@ -1419,7 +1419,7 @@
     "command-line-args": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha1-+NGRbsuQ6eEh7aZCjkEwC/tkzEY=",
+      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "requires": {
         "array-back": "2.0.0",
         "find-replace": "1.0.3",
@@ -1429,7 +1429,7 @@
     "command-line-commands": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
-      "integrity": "sha1-xYqhPceMBgOO1nB35XrQmm+Fj0Y=",
+      "integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
       "requires": {
         "array-back": "2.0.0"
       }
@@ -1437,7 +1437,7 @@
     "command-line-usage": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.0.1.tgz",
-      "integrity": "sha1-2JzxbIrnHo6KbmqrrhZSr3b/ZE4=",
+      "integrity": "sha512-IqYzZuXizukrdhnbdUj2hh4iceycow+Jn10mER4lwU4IapYvl5ZzoRPsj5Yraew5oRk4yfFKMuULGvAfb5o29w==",
       "requires": {
         "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
@@ -1525,7 +1525,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "4.2.0"
           }
@@ -1573,7 +1573,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1606,7 +1606,7 @@
     "defekt": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/defekt/-/defekt-0.2.0.tgz",
-      "integrity": "sha1-hCHzgSBr4Jy7sA8SQczemb3ezqU=",
+      "integrity": "sha512-gEVkZvXw78Z1OEn8cbbZy7F/zzEtv+nzwoIFl/OprRcfY5juqtrOtFWrTvzyroCIq0a+GCiTk4yHRWnvHORWqw==",
       "requires": {
         "inherits": "2.0.3"
       }
@@ -1709,7 +1709,7 @@
     "docker-compare": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/docker-compare/-/docker-compare-0.2.0.tgz",
-      "integrity": "sha1-/sOyZCJdYEYuiQQfGhR2cM9pqsE="
+      "integrity": "sha512-PdermtTAcJwtfa25xlHeafwiv3WtsRquXPgCELIXMqqOP+la2x+7jxhpl+Xl6mlbY48y47LJPVbYRQ4lRkucSQ=="
     },
     "doctrine": {
       "version": "2.0.0",
@@ -1796,7 +1796,7 @@
     "es-abstract": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
-      "integrity": "sha1-aQgpoHyuNrIi5/2bdcDQVz6yUic=",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -2032,7 +2032,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "esquery": {
       "version": "1.0.0",
@@ -2144,7 +2144,7 @@
     "external-editor": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha1-UsJJo5gbm6GHx8rPW+tQvx2Rprw=",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "requires": {
         "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
@@ -2448,7 +2448,7 @@
     "fsevents": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha1-MoK3E/s62A7eDp/PRhG1qm/AM/Q=",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3214,14 +3214,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3230,6 +3222,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3347,7 +3347,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3387,7 +3387,7 @@
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha1-XErYfyg0xLm06EVJ3B4GUPs4wks=",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -3413,7 +3413,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -3556,7 +3556,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -4110,7 +4110,7 @@
             "string-width": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
@@ -4181,7 +4181,7 @@
     "gulp-istanbul": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/gulp-istanbul/-/gulp-istanbul-1.1.2.tgz",
-      "integrity": "sha1-r2X6KL/bNXbaq5Xc+qcypqJ8Wgc=",
+      "integrity": "sha512-53+BDhGlGNHYfeFh/mSXWhNu9wSFmE8qAEFj6ViMiWzTwI9pYxedUxMmGfigwaddsHHQxBl9TgnzUydrX84Kog==",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
@@ -4392,7 +4392,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -4409,7 +4409,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4433,7 +4433,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "http-signature": {
@@ -4449,12 +4449,12 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha1-xOcVRV9gc6jX5drnLS/J1xZj26Y="
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4493,7 +4493,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
         "ansi-escapes": "3.0.0",
         "chalk": "2.1.0",
@@ -4648,7 +4648,7 @@
     "is-my-json-valid": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -4702,7 +4702,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -4933,7 +4933,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -4948,7 +4948,7 @@
     "jschardet": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha1-xRn2KfhrOlvtuliojTETCe7Al/k="
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
     },
     "jsesc": {
       "version": "1.3.0",
@@ -5333,7 +5333,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -5474,7 +5474,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -5505,7 +5505,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -5616,7 +5616,7 @@
     "nodeenv": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/nodeenv/-/nodeenv-0.3.0.tgz",
-      "integrity": "sha1-m+YEazVCGK2cK1najIULH05zX0g="
+      "integrity": "sha512-kI2GnGj4avchEdnsR2i/nEL7xupZcGahtL7sAhwSjTXe9Ku/FaC15nxYENGatZ2ka+XXuRyASCoTXANzP75U2w=="
     },
     "nopt": {
       "version": "3.0.6",
@@ -5630,7 +5630,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -6128,7 +6128,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "ramda": {
       "version": "0.24.1",
@@ -6139,7 +6139,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "3.0.0",
@@ -6201,7 +6201,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -6279,7 +6279,7 @@
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38=",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -6290,7 +6290,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -6301,7 +6301,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
@@ -6399,7 +6399,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -6428,7 +6428,7 @@
     "requestretry": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.12.2.tgz",
-      "integrity": "sha1-E844pM5OgJ88nsbUyjt7m6Ss8mw=",
+      "integrity": "sha512-wDYnH4imurLs5upu31WoPaOFfEu31qhFlF7KgpYbBsmBagFmreZZo8E/XpoQ3erCP5za+72t8k8QI4wlrtwVXw==",
       "requires": {
         "extend": "3.0.1",
         "lodash": "4.17.4",
@@ -6471,7 +6471,7 @@
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "1.0.5"
       }
@@ -6513,7 +6513,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -6521,7 +6521,7 @@
     "roboter": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/roboter/-/roboter-0.15.4.tgz",
-      "integrity": "sha1-MzY+qc0P4hiswdRrFn4ncwQp6nY=",
+      "integrity": "sha512-WH+OE+ullyjNtHtTjyL+D5zk+Z7shUjJHmwyyUdqwkHazlkVGXGDyiq8MfKlhqGkyMdLBNUE2NLRd5seMyEJvg==",
       "dev": true,
       "requires": {
         "async": "2.4.1",
@@ -6825,7 +6825,7 @@
             "string-width": {
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
                 "is-fullwidth-code-point": "2.0.0",
@@ -6848,7 +6848,7 @@
     "roboter-server": {
       "version": "0.15.4",
       "resolved": "https://registry.npmjs.org/roboter-server/-/roboter-server-0.15.4.tgz",
-      "integrity": "sha1-AezPEc7PWAfDkPUZ/ZQAJJfWkGw=",
+      "integrity": "sha512-1zHAasiXnorUPWj/imjWhzQ+/xv6ehpTT/FvZNx/mIcj8TtbGzirG9ClDfs6KQj90QutdMo/6CDA6jodXJ+7Vw==",
       "dev": true,
       "requires": {
         "babel-cli": "6.23.0",
@@ -6882,12 +6882,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "sequencify": {
       "version": "0.0.7",
@@ -6969,7 +6969,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
       }
@@ -6995,7 +6995,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "0.5.7"
@@ -7062,27 +7062,27 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "stringify-object": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
-      "integrity": "sha1-JyDC7/lAhUyBn27iUqrrWB8wYk0=",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
       "dev": true,
       "requires": {
         "get-own-enumerable-property-symbols": "2.0.1",
@@ -7175,7 +7175,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
         "has-flag": "2.0.0"
       }
@@ -7183,7 +7183,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
         "ajv": "5.2.3",
         "ajv-keywords": "2.1.0",
@@ -7209,7 +7209,7 @@
     "table-layout": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.2.tgz",
-      "integrity": "sha1-EOkEPBQqHi0VXaclfkePDvSYF4Y=",
+      "integrity": "sha512-tygyl5+eSHj4chpq5Zfy6cpc7MOUBClAW9ozghFH7hg9bAUzShOYn+/vUzTRkKOSLJWKfgYtP2tAU2c0oAD8eg==",
       "requires": {
         "array-back": "2.0.0",
         "deep-extend": "0.5.0",
@@ -7278,7 +7278,7 @@
     "thunks": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/thunks/-/thunks-4.9.0.tgz",
-      "integrity": "sha1-RsANuZaFg7OkIeDJKF6si5/dsxo=",
+      "integrity": "sha512-Bp4sGtcf8/SAgX2XBXYH2Crc7ESL7xuTuQ5kx84Tvz7VSkLFg6bfjFBpRmX2DLAWaLeK6q32ogqAnXcr5NAQtw==",
       "dev": true
     },
     "tildify": {
@@ -7299,7 +7299,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
         "os-tmpdir": "1.0.2"
       }
@@ -7322,7 +7322,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs=",
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
       "dev": true
     },
     "tough-cookie": {
@@ -7495,7 +7495,7 @@
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "requires": {
         "define-properties": "1.1.2",
         "object.getownpropertydescriptors": "2.0.3"
@@ -7504,7 +7504,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -7678,7 +7678,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -7704,7 +7704,7 @@
     "wordwrapjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "requires": {
         "reduce-flatten": "1.0.1",
         "typical": "2.6.1"

--- a/test/units/application/getConfigurationTests.js
+++ b/test/units/application/getConfigurationTests.js
@@ -71,10 +71,10 @@ suite('application/getConfiguration', () => {
     }).is.throwingAsync(ex => ex.code === 'EVERSIONNOTFOUND');
   });
 
-  test('throws an error if package.json does not contain node environment.', async () => {
+  test('does not throw an error if package.json does not contain node environment.', async () => {
     await assert.that(async () => {
       await getConfiguration({ directory: directory.doesNotContainNodeEnvironment });
-    }).is.throwingAsync(ex => ex.code === 'ECONFIGURATIONMALFORMED');
+    }).is.not.throwingAsync();
   });
 
   test('throws an error if package.json does not contain an port.', async () => {

--- a/test/units/network/getIpAddressesTests.js
+++ b/test/units/network/getIpAddressesTests.js
@@ -25,7 +25,9 @@ suite('network/getIpAddresses', () => {
   test('returns addresses if host is given.', async () => {
     const addresses = await getIpAddresses('localhost');
 
-    assert.that(addresses).is.equalTo([
+    assert.that(
+      addresses.filter(item => item.address === '127.0.0.1' || item.address === '::1')
+    ).is.equalTo([
       { address: '127.0.0.1', family: 4 },
       { address: '::1', family: 6 }
     ]);


### PR DESCRIPTION
Hi @grundhoeferj!

While testing the new CLI, @revrng has discovered a bug: In the `wolkenkit` section of an application's `package.json` file, the property `node/environment` was mandatory (but should be optional).

I have fixed this, adjusted the tests, and verified that everything still works on AWS.

Could you please have a look at this PR, and squash/merge this, if you are fine with it?