### PR TITLE
Fix docker commands for windows.

### DIFF
--- a/lib/docker/ensureNetworkExists.js
+++ b/lib/docker/ensureNetworkExists.js
@@ -19,7 +19,7 @@ const ensureNetworkExists = async function (options) {
 
   const environmentVariables = await getEnvironmentVariables({ configuration, env });
 
-  const { stdout } = await shell.exec(`docker network ls --format '{{json .}}'`, {
+  const { stdout } = await shell.exec(`docker network ls --format "{{json .}}"`, {
     env: environmentVariables
   });
 

--- a/lib/docker/getContainers.js
+++ b/lib/docker/getContainers.js
@@ -27,7 +27,7 @@ const getContainers = async function (options) {
 
   const filter = flatten(
     map(where, (keyValuePair, criterion) =>
-      map(keyValuePair, (value, key) => `--filter '${criterion}=${key}=${value}'`)));
+      map(keyValuePair, (value, key) => `--filter "${criterion}=${key}=${value}"`)));
 
   const { stdout } = await shell.exec(`docker ps --all ${filter.join(' ')} --format "{{json .}}"`, {
     env: environmentVariables

--- a/lib/docker/getContainers.js
+++ b/lib/docker/getContainers.js
@@ -29,7 +29,7 @@ const getContainers = async function (options) {
     map(where, (keyValuePair, criterion) =>
       map(keyValuePair, (value, key) => `--filter '${criterion}=${key}=${value}'`)));
 
-  const { stdout } = await shell.exec(`docker ps --all ${filter.join(' ')} --format '{{json .}}'`, {
+  const { stdout } = await shell.exec(`docker ps --all ${filter.join(' ')} --format "{{json .}}"`, {
     env: environmentVariables
   });
 

--- a/lib/docker/ping.js
+++ b/lib/docker/ping.js
@@ -47,7 +47,7 @@ const ping = async function (options) {
   let output;
 
   try {
-    output = await shell.exec(`docker version --format '{{json .}}'`, {
+    output = await shell.exec(`docker version --format "{{json .}}"`, {
       env: environmentVariables
     });
   } catch (ex) {


### PR DESCRIPTION
Since on windows the argument `--format` expect double quotes , we have to change this. Notice: double quotes also works on unix systems.