### PR TITLE
Make certificate matching pay attention to wildcards. Closes thenativeweb/org#491

### DIFF
--- a/lib/certificate/index.js
+++ b/lib/certificate/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const requireDir = require('require-dir');
+
+module.exports = requireDir(__dirname);

--- a/lib/certificate/isNameMatching.js
+++ b/lib/certificate/isNameMatching.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const numberOfDots = function (text) {
+  return text.split('.').length - 1;
+};
+
+const isMatching = function (left, right) {
+  if (left === right) {
+    return true;
+  }
+  if (left.startsWith('*.')) {
+    if (numberOfDots(left) !== numberOfDots(right)) {
+      return false;
+    }
+
+    const fixedPartOfLeft = left.substring(2),
+          fixedPartOfRight = right.substring(right.indexOf('.') + 1);
+
+    if (fixedPartOfLeft === fixedPartOfRight) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isNameMatching = function (options) {
+  if (!options) {
+    throw new Error('Options are missing.');
+  }
+  if (!options.certificate) {
+    throw new Error('Certificate is missing.');
+  }
+  if (!options.name) {
+    throw new Error('Name is missing.');
+  }
+
+  const { certificate, name } = options;
+
+  if (isMatching(certificate.subject.commonName, name)) {
+    return true;
+  }
+  if (certificate.subject.alternativeNames && certificate.subject.alternativeNames.find(san => isMatching(san, name))) {
+    return true;
+  }
+
+  return false;
+};
+
+module.exports = isNameMatching;

--- a/lib/wolkenkit/commands/health/checkCertificate.js
+++ b/lib/wolkenkit/commands/health/checkCertificate.js
@@ -2,7 +2,7 @@
 
 const application = require('../../../application'),
       errors = require('../../../errors'),
-      { isNameMatching } = require('../../../checkCertificate');
+      { isNameMatching } = require('../../../certificate');
 
 const checkCertificate = async function (options, progress) {
   if (!options) {

--- a/lib/wolkenkit/commands/health/checkCertificate.js
+++ b/lib/wolkenkit/commands/health/checkCertificate.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const application = require('../../../application'),
-      errors = require('../../../errors');
+      errors = require('../../../errors'),
+      { isNameMatching } = require('../../../checkCertificate');
 
 const checkCertificate = async function (options, progress) {
   if (!options) {
@@ -46,9 +47,8 @@ const checkCertificate = async function (options, progress) {
   if (certificate.subject.commonName === certificate.issuer.commonName) {
     progress({ message: 'Application certificate is self-signed.', type: 'warn' });
   }
-  if (certificate.subject.commonName !== host && (certificate.subject.alternativeNames && !certificate.subject.alternativeNames.includes(host))) {
+  if (!isNameMatching({ certificate, name: host })) {
     progress({ message: `Application certificate does not match application host ${host}.`, type: 'info' });
-
     throw new errors.CertificateMismatch();
   }
 
@@ -56,12 +56,10 @@ const checkCertificate = async function (options, progress) {
 
   if (certificate.metadata.validTo < now) {
     progress({ message: 'Application certificate has expired.', type: 'info' });
-
     throw new errors.CertificateExpired();
   }
   if (now < certificate.metadata.validFrom) {
     progress({ message: 'Application certificate is not yet valid.', type: 'info' });
-
     throw new errors.CertificateNotYetValid();
   }
 };

--- a/test/stories/shared/applicationLifecycleTests.js
+++ b/test/stories/shared/applicationLifecycleTests.js
@@ -20,9 +20,9 @@ const applicationLifecycleTests = async function (runtime) {
 
       const { code, stderr, stdout } = await wolkenkit('init', { template }, { cwd: applicationDirectory });
 
-      assert.that(code).is.equalTo(0);
-      assert.that(stdout).is.equalTo(`  Initializing a new application...\n  Cloning ${template}...\n✓ Initialized a new application.\n`);
       assert.that(stderr).is.equalTo('');
+      assert.that(stdout).is.equalTo(`  Initializing a new application...\n  Cloning ${template}...\n✓ Initialized a new application.\n`);
+      assert.that(code).is.equalTo(0);
 
       const directoryList = await getDirectoryList(applicationDirectory);
 

--- a/test/units/certificate/isNameMatchingTests.js
+++ b/test/units/certificate/isNameMatchingTests.js
@@ -1,0 +1,171 @@
+'use strict';
+
+const assert = require('assertthat');
+
+const isNameMatching = require('../../../lib/certificate/isNameMatching');
+
+suite('certificate/isNameMatching', () => {
+  test('is a function.', done => {
+    assert.that(isNameMatching).is.ofType('function');
+    done();
+  });
+
+  test('throws an error when options are missing.', done => {
+    assert.that(() => {
+      isNameMatching();
+    }).is.throwing('Options are missing.');
+    done();
+  });
+
+  test('throws an error when certificate is missing.', done => {
+    assert.that(() => {
+      isNameMatching({});
+    }).is.throwing('Certificate is missing.');
+    done();
+  });
+
+  test('throws an error when name is missing.', done => {
+    assert.that(() => {
+      isNameMatching({ certificate: {}});
+    }).is.throwing('Name is missing.');
+    done();
+  });
+
+  test('returns true when the common name matches the expected name.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: 'www.example.com' }
+      },
+      name: 'www.example.com'
+    })).is.true();
+    done();
+  });
+
+  test('returns false when the common name does not match the expected name.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: 'www.example.com' }
+      },
+      name: 'example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns true when the common name matches the expected name using a wildcard.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: '*.example.com' }
+      },
+      name: 'www.example.com'
+    })).is.true();
+    done();
+  });
+
+  test('returns false when the common name does not match the expected name using a wildcard.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: '*.example.com' }
+      },
+      name: 'example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns false when the common name does not match the expected name using a wildcard because of nesting.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: '*.example.com' }
+      },
+      name: 'foo.bar.example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns false when the common name does not match the expected name using a wildcard because the domain itself is wrong.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: { commonName: '*.example.com' }
+      },
+      name: 'foo.bar.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns true when the subject alternative names include the expected name.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'foo.bar.com',
+          alternativeNames: [ 'example.com', 'www.example.com' ]
+        }
+      },
+      name: 'www.example.com'
+    })).is.true();
+    done();
+  });
+
+  test('returns false when the subject alternative names do not include the expected name.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'foo.bar.com',
+          alternativeNames: [ 'example.com', 'www.example.com' ]
+        }
+      },
+      name: 'test.example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns true when the subject alternative names match the expected name using a wildcard.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'foo.bar.com',
+          alternativeNames: [ 'example.com', '*.example.com' ]
+        }
+      },
+      name: 'www.example.com'
+    })).is.true();
+    done();
+  });
+
+  test('returns false when the subject alternative names do not match the expected name using a wildcard.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'test.example.com',
+          alternativeNames: [ '*.example.com' ]
+        }
+      },
+      name: 'example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns false when the subject alternative names do not match the expected name using a wildcard because of nesting.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'test.example.com',
+          alternativeNames: [ '*.example.com' ]
+        }
+      },
+      name: 'foo.bar.example.com'
+    })).is.false();
+    done();
+  });
+
+  test('returns false when the subject alternative names do not match the expected name using a wildcard because the domain itself is wrong.', done => {
+    assert.that(isNameMatching({
+      certificate: {
+        subject: {
+          commonName: 'test.example.com',
+          alternativeNames: [ 'example.com', '*.example.com' ]
+        }
+      },
+      name: 'foo.bar.com'
+    })).is.false();
+    done();
+  });
+});


### PR DESCRIPTION
Hi @grundhoeferj 😊 

I have fixed thenativeweb/org#491 … could you please review it, and squash/merge it if you are fine with it?

The AWS tests run fine, and I have also adjusted the unit tests, they are green, too.