### PR TITLE
Support object rest operator when linting code. Close #122

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "assertthat": "2.0.1",
-    "dir-compare": "1.6.0",
+    "dir-compare": "1.7.1",
     "measure-time": "3.1.1",
     "p-queue": "3.0.0",
     "roboter": "3.0.4",

--- a/src/wolkenkit/commands/shared/validateCode.js
+++ b/src/wolkenkit/commands/shared/validateCode.js
@@ -17,7 +17,7 @@ const validateCode = function ({ directory }, progress) {
   const cliEngine = new eslint.CLIEngine({
     envs: [ 'node', 'es6' ],
     parserOptions: {
-      ecmaVersion: 2017,
+      ecmaVersion: 2019,
       ecmaFeatures: {}
     },
     rules: {


### PR DESCRIPTION
Hi @grundhoeferj 😊 

@mattwagl mentioned in #122 that we use an outdated language spec to validate the code of wolkenkit applications, and I've updated the responsible line of code.

Could you please have a look at this, and squash / merge it, if you are fine with this?