### PR TITLE
Improve error output when a CLI command fails. Closes #135

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -891,9 +891,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "10.12.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.27.tgz",
+      "integrity": "sha512-e9wgeY6gaY21on3ve0xAjgBVjGDWq/xUteK0ujsE53bUoxycMkqfnkUgMt6ffZtykZ5X12Mg3T7Pw4TRCObDKg==",
       "dev": true
     },
     "JSONStream": {
@@ -906,9 +906,9 @@
       }
     },
     "acorn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-jsx": {
       "version": "5.0.1",
@@ -916,9 +916,9 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
     },
     "ajv": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -942,7 +942,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-red": {
@@ -1068,14 +1068,31 @@
       "dev": true
     },
     "assertthat": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertthat/-/assertthat-2.0.1.tgz",
-      "integrity": "sha512-3exvD761aKVP9DKx/KIQD1XetSLjj5pkaRJooThfJyVhDglwlC0Jx5SavMkJwrfkYvHHUnztLlvHGpgkSebZbg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/assertthat/-/assertthat-2.0.3.tgz",
+      "integrity": "sha512-yzhG7bBizN/BpF3lVbulbDgK/7K7JYVikx0U0q6Z/kWevtfKWPBdtJB6HlxviJF9wVPZz3ExAN1/6zGmwYA0aA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.2.0",
-        "comparejs": "1.0.1",
+        "@babel/runtime": "7.3.1",
+        "comparejs": "1.0.3",
         "stringify-object": "3.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
       }
     },
     "assign-symbols": {
@@ -1131,7 +1148,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -1365,7 +1382,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -1374,7 +1391,7 @@
     },
     "bluebird": {
       "version": "3.4.1",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
       "integrity": "sha1-tzHd9I4t077awudeEhWhG8uR+gc=",
       "dev": true
     },
@@ -1471,9 +1488,9 @@
       "dev": true
     },
     "buffer-writer": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
-      "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1646,7 +1663,8 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -1786,7 +1804,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -1831,7 +1849,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -1846,6 +1864,17 @@
         "@babel/runtime": "7.2.0",
         "formats": "1.0.0",
         "uuidv4": "2.0.0"
+      },
+      "dependencies": {
+        "uuidv4": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-2.0.0.tgz",
+          "integrity": "sha512-sAUlwUVepcVk6bwnaW/oi6LCwMdueako5QQzRr90ioAVVcms6p1mV0PaSxK8gyAC4CRvKddsk217uUpZUbKd2Q==",
+          "requires": {
+            "sha-1": "0.1.1",
+            "uuid": "3.3.2"
+          }
+        }
       }
     },
     "common-tags": {
@@ -1854,9 +1883,9 @@
       "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "comparejs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/comparejs/-/comparejs-1.0.1.tgz",
-      "integrity": "sha512-bmE6NL48lmvoLrJeEIB078Jov83qWrzmQ+kYyXnVVKnLRY/j5h8Bq7aksQQmFwaTFowo1Ge4OdjaL5TH5X5SCA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/comparejs/-/comparejs-1.0.3.tgz",
+      "integrity": "sha512-X/pMtrKOz3mUduz8jAOwi7oDmp9p7QTQAVTVKO5o7Ji31NLcGb3JyzX/Gp0nFJlNqeU3CvtKDW7eYXCuExF4eA==",
       "dev": true
     },
     "component-emitter": {
@@ -2083,7 +2112,7 @@
     },
     "denque": {
       "version": "1.2.3",
-      "resolved": "http://registry.npmjs.org/denque/-/denque-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.2.3.tgz",
       "integrity": "sha512-BOjyD1zPf7gqgXlXBCnCsz84cbRNfqpQNvWOUiw3Onu9s7a2afW2LyHzctoie/2KELfUoZkNHTnW02C3hCU20w=="
     },
     "depcheck": {
@@ -2135,9 +2164,9 @@
       "dev": true
     },
     "dir-compare": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-1.6.0.tgz",
-      "integrity": "sha512-YYD1gRrNIeOAIYc+3pS3BjOcrhzrMTXEigWiYOO5r2Y3tKflgZbJGBJUgUvaz0QFMyybCnOIUtUggkVopLhPUA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-1.7.1.tgz",
+      "integrity": "sha512-5H/h0a9u5F+/04W3VKMFDeZgFrrX6y7sk01z284/zUhg3hhjQN6Udvxcq8RFIikQP2rRvxlw3y1FmrvVzjc3Cw==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -2188,6 +2217,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -2241,6 +2271,11 @@
       "integrity": "sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -2293,49 +2328,53 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.12.1.tgz",
-      "integrity": "sha512-54NV+JkTpTu0d8+UYSA8mMKAG4XAsaOrozA9rCW7tgneg1mevcL7wIotPC+fZ0SkWwdhNqoXoxnQCTBp7UvTsg==",
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.1.tgz",
+      "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
+        "ajv": "^6.9.1",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
+        "doctrine": "^3.0.0",
         "eslint-scope": "^4.0.0",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
+        "espree": "^5.0.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
+        "inquirer": "^6.2.2",
         "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
         "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^5.5.1",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
+        "table": "^5.2.3",
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
         "ansi-regex": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
@@ -2354,6 +2393,14 @@
             "ms": "^2.1.1"
           }
         },
+        "doctrine": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+          "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
         "external-editor": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -2364,26 +2411,54 @@
             "tmp": "^0.0.33"
           }
         },
-        "inquirer": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
-          "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+        "file-entry-cache": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+          "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
           "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
+            "flat-cache": "^2.0.1"
+          }
+        },
+        "flat-cache": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+          "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+          "requires": {
+            "flatted": "^2.0.0",
+            "rimraf": "2.6.3",
+            "write": "1.0.3"
+          }
+        },
+        "inquirer": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+          "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+          "requires": {
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
             "cli-cursor": "^2.1.0",
             "cli-width": "^2.0.0",
-            "external-editor": "^3.0.0",
+            "external-editor": "^3.0.3",
             "figures": "^2.0.0",
-            "lodash": "^4.17.10",
+            "lodash": "^4.17.11",
             "mute-stream": "0.0.7",
             "run-async": "^2.2.0",
-            "rxjs": "^6.1.0",
+            "rxjs": "^6.4.0",
             "string-width": "^2.1.0",
             "strip-ansi": "^5.0.0",
             "through": "^2.3.6"
           },
           "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
             "strip-ansi": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
@@ -2400,11 +2475,19 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "rxjs": {
-          "version": "6.3.3",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-          "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "requires": {
             "tslib": "^1.9.0"
+          }
+        },
+        "write": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+          "requires": {
+            "mkdirp": "^0.5.1"
           }
         }
       }
@@ -2468,11 +2551,11 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
-      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
       "requires": {
-        "acorn": "^6.0.2",
+        "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
@@ -2678,7 +2761,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -2792,6 +2875,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
@@ -2865,12 +2949,18 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
     },
     "follow-redirects": {
       "version": "1.6.1",
@@ -3494,7 +3584,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -3587,7 +3677,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -3793,7 +3883,7 @@
     },
     "inquirer": {
       "version": "5.2.0",
-      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
       "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
       "requires": {
         "ansi-escapes": "^3.0.0",
@@ -4026,7 +4116,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-inside": {
@@ -4692,7 +4782,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -4735,7 +4825,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4821,7 +4911,7 @@
     },
     "mysql2": {
       "version": "1.5.3",
-      "resolved": "http://registry.npmjs.org/mysql2/-/mysql2-1.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-1.5.3.tgz",
       "integrity": "sha512-Oov36YQSeciNP9SeqE7je4eWgeGADOorXLmsqhtxOJmPGUOJSNJT0s6/eq1Byy4nhXTRQUvlMHsI4Q/eMEs88Q==",
       "requires": {
         "cardinal": "1.0.0",
@@ -4856,7 +4946,7 @@
     },
     "named-placeholders": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.1.tgz",
       "integrity": "sha1-O3oNJiA910s6nfTJz7gnsvuQfmQ=",
       "requires": {
         "lru-cache": "2.5.0"
@@ -4864,7 +4954,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "2.5.0",
-          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
           "integrity": "sha1-2COIrpyWC+y+oMc7uet5tsbOmus="
         }
       }
@@ -5090,7 +5180,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "output-file-sync": {
@@ -5128,9 +5218,9 @@
       }
     },
     "p-queue": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-3.0.0.tgz",
-      "integrity": "sha512-2tv/MRmPXfmfnjLLJAHl+DdU8p2DhZafAnlpm/C/T5BpF5L9wKz5tMin4A4N2zVpJL2YMhPlRmtO7s5EtNrjfA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-3.1.0.tgz",
+      "integrity": "sha512-kFa39NE4N0+fua9kdI/w8FPB0Gmv0lenS+2FQ7J/8dL4hbnfk1AqXSZJXuUKI2HL1GMzzyPSepwGKqsTmP2dDQ==",
       "dev": true
     },
     "p-try": {
@@ -5198,7 +5288,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -5234,22 +5324,22 @@
       }
     },
     "pg": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.3.tgz",
-      "integrity": "sha1-97b5P1NA7MJZavu5ShPj1rYJg0s=",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.8.0.tgz",
+      "integrity": "sha512-yS3C9YD+ft0H7G47uU0eKajgTieggCXdA+Fxhm5G+wionY6kPBa8BEVDwPLMxQvkRkv3/LXiFEqjZm9gfxdW+g==",
       "requires": {
-        "buffer-writer": "1.0.1",
+        "buffer-writer": "2.0.0",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "~2.0.3",
-        "pg-types": "~1.12.1",
+        "pg-pool": "^2.0.4",
+        "pg-types": "~2.0.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
       },
       "dependencies": {
         "semver": {
           "version": "4.3.2",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
           "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
         }
       }
@@ -5260,9 +5350,14 @@
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
     },
     "pg-cursor": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-1.3.0.tgz",
-      "integrity": "sha1-siDxkIl2t7QNqjc8etpfyoI6sNk="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.0.0.tgz",
+      "integrity": "sha512-/gYHadqLurektHk6HXiL0hSrn+RZfowkLr+ftC0lLoLBlIm8JIdk9f9g71EEjK63XxqhFqcykHuxQLFzSeyzdQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-pool": {
       "version": "2.0.6",
@@ -5270,19 +5365,20 @@
       "integrity": "sha512-hod2zYQxM8Gt482q+qONGTYcg/qVcV32VHVPtktbBJs0us3Dj7xibISw0BAAXVMCzt8A/jhfJvpZaxUlqtqs0g=="
     },
     "pg-query-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-1.1.1.tgz",
-      "integrity": "sha1-Zel0Nu+AnR4WDrqE6/EbnkdC6rQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-2.0.0.tgz",
+      "integrity": "sha512-EInD7AOhnJVFIgN8BSEbKA6MKyn20dDGPsJEuhxiNaWpmveNgnmn3W1BmYm9pa6LakioR/WTi7ecWA44GBRKig==",
       "requires": {
-        "pg-cursor": "1.3.0"
+        "pg-cursor": "2.0.0"
       }
     },
     "pg-types": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
-      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.0.0.tgz",
+      "integrity": "sha512-THUD7gQll5tys+5eQ8Rvs7DjHiIC3bLqixk3gMN9Hu8UrCBAOjf35FoI39rTGGc3lM2HU/R+Knpxvd11mCwOMA==",
       "requires": {
-        "postgres-array": "~1.0.0",
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
         "postgres-bytea": "~1.0.0",
         "postgres-date": "~1.0.0",
         "postgres-interval": "^1.1.0"
@@ -5304,7 +5400,8 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
     },
     "portscanner": {
       "version": "2.2.0",
@@ -5322,9 +5419,9 @@
       "dev": true
     },
     "postgres-array": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
-      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
     },
     "postgres-bytea": {
       "version": "1.0.0",
@@ -5337,9 +5434,9 @@
       "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
     },
     "postgres-interval": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
-      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -5451,7 +5548,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -5479,7 +5576,7 @@
     },
     "readable-stream": {
       "version": "2.3.5",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
       "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -6304,9 +6401,9 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
-      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "requires": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -6603,7 +6700,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -6625,14 +6722,39 @@
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "table": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.2.1.tgz",
-      "integrity": "sha512-qmhNs2GEHNqY5fd2Mo+8N1r2sw/rvTAAvBZTaTx+Y7PHLypqyrxr1MdIu0pLw6Xvl/Gi4ONu/sdceP8vvUjkyA==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "requires": {
-        "ajv": "^6.6.1",
+        "ajv": "^6.9.1",
         "lodash": "^4.17.11",
-        "slice-ansi": "2.0.0",
-        "string-width": "^2.1.1"
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+        },
+        "string-width": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
+          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "requires": {
+            "ansi-regex": "^4.0.0"
+          }
+        }
       }
     },
     "table-layout": {
@@ -6683,7 +6805,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -6721,7 +6843,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
         }
       }
@@ -6750,7 +6872,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
@@ -7065,11 +7187,10 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "uuidv4": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-2.0.0.tgz",
-      "integrity": "sha512-sAUlwUVepcVk6bwnaW/oi6LCwMdueako5QQzRr90ioAVVcms6p1mV0PaSxK8gyAC4CRvKddsk217uUpZUbKd2Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-3.0.1.tgz",
+      "integrity": "sha512-PPzksdWRl2a5C9hrs3OOYrArTeyoR0ftJ3jtOy+BnVHkT2UlrrzPNt9nTdiGuxmQItHM/AcTXahwZZC57Njojg==",
       "requires": {
-        "sha-1": "0.1.1",
         "uuid": "3.3.2"
       }
     },
@@ -7158,67 +7279,47 @@
         "streamtoarray": "0.1.4",
         "uuidv4": "2.0.0",
         "ws": "6.1.0"
+      },
+      "dependencies": {
+        "uuidv4": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-2.0.0.tgz",
+          "integrity": "sha512-sAUlwUVepcVk6bwnaW/oi6LCwMdueako5QQzRr90ioAVVcms6p1mV0PaSxK8gyAC4CRvKddsk217uUpZUbKd2Q==",
+          "dev": true,
+          "requires": {
+            "sha-1": "0.1.1",
+            "uuid": "3.3.2"
+          }
+        }
       }
     },
     "wolkenkit-eventstore": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/wolkenkit-eventstore/-/wolkenkit-eventstore-2.5.0.tgz",
-      "integrity": "sha512-A1ZnXcSLlqGcyR0UlsF5NSFSmBI/IDR00PUPHz24p+thD8eUeH+a2ZrPoO1+w8sm9UQ61NUSajEfOMn6m+eZGA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/wolkenkit-eventstore/-/wolkenkit-eventstore-2.5.1.tgz",
+      "integrity": "sha512-/NHxDwOzl48x/QAeLmk120gCwP93JcstTv3i+NZa4ZW3ipeh255FC9BHl82rr9P/6L5FtSp0zY+1sx0t/GOO7Q==",
       "requires": {
-        "async-retry": "1.2.1",
+        "async-retry": "1.2.3",
         "babel-runtime": "6.26.0",
-        "commands-events": "1.0.3",
+        "commands-events": "1.0.4",
         "dsn-parser": "1.0.1",
         "limit-alphanumeric": "1.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mongodb": "3.1.1",
         "mysql2": "1.5.3",
-        "pg": "7.4.3",
-        "pg-query-stream": "1.1.1",
+        "pg": "7.8.0",
+        "pg-query-stream": "2.0.0",
         "tarn": "1.1.4",
         "tedious": "2.6.3",
-        "uuidv4": "1.0.1"
+        "uuidv4": "2.0.0"
       },
       "dependencies": {
-        "async-retry": {
-          "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/async-retry/-/async-retry-1.2.1.tgz",
-          "integrity": "sha512-FadV8UDcyZDjzb6eV7MCJj0bfrNjwKw7/X0QHPFCbYP6T20FXgZCYXpJKlQC8RxEQP1E6Xs8pNHdh3bcrZAuAw==",
-          "requires": {
-            "retry": "0.10.1"
-          }
-        },
-        "commands-events": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/commands-events/-/commands-events-1.0.3.tgz",
-          "integrity": "sha512-8+bvRwn33Sb8UrybOZgev6gJEr1D5gneqUY0hd3VVwtgH3dqLqIguzjVxnZW0KxPg57wDXy8qoCj1BMjn6P/Jg==",
-          "requires": {
-            "formats": "1.0.0",
-            "uuidv4": "1.0.1"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-        },
-        "retry": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
         "uuidv4": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-1.0.1.tgz",
-          "integrity": "sha512-Anb/VRbs8Xqvz3C4um6JmSVn+HQG4M7Opa6xqoMZFf0wL+AlDDHGRFvGtuspGctlkfOREzDEDjyPGjS7bcs89A==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-2.0.0.tgz",
+          "integrity": "sha512-sAUlwUVepcVk6bwnaW/oi6LCwMdueako5QQzRr90ioAVVcms6p1mV0PaSxK8gyAC4CRvKddsk217uUpZUbKd2Q==",
           "requires": {
             "sha-1": "0.1.1",
-            "uuid": "3.2.1"
+            "uuid": "3.3.2"
           }
         }
       }
@@ -7293,6 +7394,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4068,6 +4068,11 @@
       "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4979,10 +4984,13 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
+    "opn": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
     },
     "optionator": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "newline-json": "0.1.1",
     "nodeenv": "1.0.0",
     "object-hash": "1.3.1",
-    "open": "0.0.5",
+    "opn": "5.4.0",
     "portscanner": "2.2.0",
     "processenv": "1.1.0",
     "pump": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "defekt": "2.0.1",
     "docker-compare": "0.2.0",
     "dotfile-json": "1.0.3",
-    "eslint": "5.12.1",
+    "eslint": "5.14.1",
     "findsuggestions": "1.0.0",
     "flat": "4.1.0",
     "freeport": "1.0.5",
@@ -69,16 +69,16 @@
     "tar": "4.4.8",
     "update-notifier": "2.5.0",
     "util.promisify": "1.0.0",
-    "uuidv4": "2.0.0",
+    "uuidv4": "3.0.1",
     "validate-value": "3.0.0",
-    "wolkenkit-eventstore": "2.5.0"
+    "wolkenkit-eventstore": "2.5.1"
   },
   "devDependencies": {
-    "assertthat": "2.0.1",
-    "dir-compare": "1.7.1",
+    "assertthat": "2.0.3",
+    "dir-compare": "1.7.2",
     "measure-time": "3.1.1",
-    "p-queue": "3.0.0",
-    "roboter": "3.0.4",
+    "p-queue": "3.1.0",
+    "roboter": "4.0.0",
     "wolkenkit-client": "3.1.0"
   },
   "scripts": {

--- a/src/bin/wolkenkit.js
+++ b/src/bin/wolkenkit.js
@@ -59,6 +59,12 @@ updateNotifier({ pkg: packageJson }).notify();
   /* eslint-enable no-underscore-dangle */
 
   const handleException = function (ex) {
+    // In case of an exception, always enable verbose mode so that the exception
+    // details are shown.
+    if (!process.argv.includes('--verbose')) {
+      process.argv.push('--verbose');
+    }
+
     if (ex.message) {
       buntstift.verbose(ex.message);
     }

--- a/src/cli/commands/register.js
+++ b/src/cli/commands/register.js
@@ -2,7 +2,7 @@
 
 const buntstift = require('buntstift'),
       getUsage = require('command-line-usage'),
-      open = require('open');
+      open = require('opn');
 
 const globalOptionDefinitions = require('../globalOptionDefinitions');
 


### PR DESCRIPTION
Hi @mattwagl 😊 

I have changed the error output so that the CLI now always shows the verbose information with the error details, no matter whether verbose mode was enabled or not. This should solve #135, and improve usability.

Can you please have a look at it, and if you are happy with it, squash and merge it?

I have already run all the tests (even the ones on AWS), and everything works so far 😊 