### PR TITLE
Implement in-memory priority queue.

### DIFF
--- a/lib/common/data/PriorityQueue/GetPriority.ts
+++ b/lib/common/data/PriorityQueue/GetPriority.ts
@@ -1,0 +1,1 @@
+export type GetPriority<TItem> = (item: TItem) => number;

--- a/lib/common/data/PriorityQueue/IsEqual.ts
+++ b/lib/common/data/PriorityQueue/IsEqual.ts
@@ -1,0 +1,1 @@
+export type IsEqual<TItem> = (leftItem: TItem, rightItem: TItem) => boolean;

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -1,9 +1,12 @@
 import { GetPriority } from './GetPriority';
+import { IsEqual } from './IsEqual';
 
 class PriorityQueue<TItem> {
   protected items: (TItem | undefined)[];
 
   protected getPriority: GetPriority<TItem>;
+
+  protected isEqual: IsEqual<TItem>;
 
   protected static getIndexOfLeftChild ({ index }: { index: number }): number {
     return (2 * index) + 1;
@@ -23,14 +26,21 @@ class PriorityQueue<TItem> {
     return (index - 2) / 2;
   }
 
-  public constructor ({ getPriority }: { getPriority: GetPriority<TItem> }) {
+  public constructor ({
+    getPriority,
+    isEqual = (leftItem, rightItem): boolean => leftItem === rightItem
+  }: {
+    getPriority: GetPriority<TItem>;
+    isEqual?: IsEqual<TItem>;
+  }) {
     this.items = [];
     this.getPriority = getPriority;
+    this.isEqual = isEqual;
   }
 
   protected getIndexOfItem ({ item }: { item: TItem }): number | undefined {
     for (const [ currentIndex, currentItem ] of this.items.entries()) {
-      if (item === currentItem) {
+      if (this.isEqual(item, currentItem!)) {
         return currentIndex;
       }
     }

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -1,0 +1,161 @@
+import { GetPriority } from './GetPriority';
+
+// Hashtable als Index für effizientes Remove (um Linear Scan wegzubekommen)
+// => Key -> Liste(Array-Index)
+
+class PriorityQueue<TItem> {
+  protected items: (TItem | undefined)[];
+
+  protected getPriority: GetPriority<TItem>;
+
+  protected static getIndexOfLeftChild ({ index }: { index: number }): number {
+    return (2 * index) + 1;
+  }
+
+  protected static getIndexOfRightChild ({ index }: { index: number }): number {
+    return (2 * index) + 2;
+  }
+
+  protected static getIndexOfParent ({ index }: { index: number }): number {
+    const isLeftChild = index % 2 === 1;
+
+    if (isLeftChild) {
+      return (index - 1) / 2;
+    }
+
+    return (index - 2) / 2;
+  }
+
+  public constructor ({ getPriority }: { getPriority: GetPriority<TItem> }) {
+    this.items = [];
+    this.getPriority = getPriority;
+  }
+
+  protected getIndexOfItem ({ item }: { item: TItem }): number | undefined {
+    for (const [ currentIndex, currentItem ] of this.items.entries()) {
+      if (item === currentItem) {
+        return currentIndex;
+      }
+    }
+  }
+
+  protected swim ({ item, index }: { item: TItem; index: number }): void {
+    if (index === 0) {
+      return;
+    }
+
+    const parentIndex = PriorityQueue.getIndexOfParent({ index });
+    const parentItem = this.items[parentIndex];
+
+    const itemPriority = this.getPriority(item);
+    const parentPriority = this.getPriority(parentItem!);
+
+    if (parentPriority <= itemPriority) {
+      return;
+    }
+
+    this.items[parentIndex] = item;
+    this.items[index] = parentItem;
+
+    this.swim({ item, index: parentIndex });
+  }
+
+  protected sink ({ item, index }: { item: TItem; index: number }): void {
+    const leftChildIndex = PriorityQueue.getIndexOfLeftChild({ index });
+    const rightChildIndex = PriorityQueue.getIndexOfRightChild({ index });
+
+    if (leftChildIndex >= this.items.length) {
+      return;
+    }
+
+    const leftChildItem = this.items[leftChildIndex];
+    const rightChildItem = this.items[rightChildIndex];
+
+    const itemPriority = this.getPriority(item);
+
+    const leftChildItemPriority = leftChildItem ?
+      this.getPriority(leftChildItem) :
+      Number.MAX_SAFE_INTEGER;
+
+    const rightChildItemPriority = rightChildItem ?
+      this.getPriority(rightChildItem) :
+      Number.MAX_SAFE_INTEGER;
+
+    if (
+      itemPriority <= leftChildItemPriority &&
+      itemPriority <= rightChildItemPriority
+    ) {
+      return;
+    }
+
+    if (leftChildItemPriority <= rightChildItemPriority) {
+      this.items[leftChildIndex] = item;
+      this.items[index] = leftChildItem;
+      this.sink({ item, index: leftChildIndex });
+    } else {
+      this.items[rightChildIndex] = item;
+      this.items[index] = rightChildItem;
+      this.sink({ item, index: rightChildIndex });
+    }
+  }
+
+  public async isEmpty (): Promise<boolean> {
+    return this.items.length === 0;
+  }
+
+  public async getNextItem (): Promise<TItem | undefined> {
+    return this.items[0];
+  }
+
+  public async getHeap (): Promise<(TItem | undefined)[]> {
+    return this.items;
+  }
+
+  public async enqueue ({ item }: { item: TItem }): Promise<void> {
+    const enqueueIndex = this.items.length;
+
+    this.items[enqueueIndex] = item;
+    this.swim({ item, index: enqueueIndex });
+  }
+
+  public async dequeue ({ item }: { item: TItem }): Promise<void> {
+    const index = this.getIndexOfItem({ item });
+
+    if (index === undefined) {
+      return;
+    }
+
+    const lastItem = this.items.pop();
+
+    if (index >= this.items.length) {
+      return;
+    }
+
+    this.items[index] = lastItem;
+
+    const itemPriority = this.getPriority(item);
+    const lastItemPriority = this.getPriority(lastItem!);
+
+    if (lastItemPriority < itemPriority) {
+      this.swim({ item: lastItem!, index });
+    } else {
+      this.sink({ item: lastItem!, index });
+    }
+  }
+
+  public async rebalance ({ item }: { item: TItem }): Promise<void> {
+    const index = this.getIndexOfItem({ item });
+
+    if (index === undefined) {
+      return;
+    }
+
+    // Run both, swim and sink. One of them may take action. Instead of trying
+    // to detect which one to call, simply call both, and one of them will do
+    // its job if necessary.
+    this.swim({ item, index });
+    this.sink({ item, index });
+  }
+}
+
+export { PriorityQueue };

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -1,6 +1,9 @@
 import { GetPriority } from './GetPriority';
 import { IsEqual } from './IsEqual';
 
+// The priority queue implemented by this class is based on a heap data
+// structure, where items with smaller values tend to become closer to the root
+// node. Hence, it's a min-heap here.
 class PriorityQueue<TItem> {
   protected items: (TItem | undefined)[];
 

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -145,7 +145,7 @@ class PriorityQueue<TItem> {
     this.repairDown({ item: lastItem!, index });
   }
 
-  public async rebalance ({ item }: { item: TItem }): Promise<void> {
+  public async repair ({ item }: { item: TItem }): Promise<void> {
     const index = this.getIndexOfItem({ item });
 
     if (index === undefined) {

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -117,7 +117,7 @@ class PriorityQueue<TItem> {
     return this.items[0];
   }
 
-  public async getHeap (): Promise<(TItem | undefined)[]> {
+  public async values (): Promise<(TItem | undefined)[]> {
     return this.items;
   }
 

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -46,7 +46,7 @@ class PriorityQueue<TItem> {
     }
   }
 
-  protected swim ({ item, index }: { item: TItem; index: number }): void {
+  protected repairUp ({ item, index }: { item: TItem; index: number }): void {
     if (index === 0) {
       return;
     }
@@ -64,10 +64,10 @@ class PriorityQueue<TItem> {
     this.items[parentIndex] = item;
     this.items[index] = parentItem;
 
-    this.swim({ item, index: parentIndex });
+    this.repairUp({ item, index: parentIndex });
   }
 
-  protected sink ({ item, index }: { item: TItem; index: number }): void {
+  protected repairDown ({ item, index }: { item: TItem; index: number }): void {
     const leftChildIndex = PriorityQueue.getIndexOfLeftChild({ index });
     const rightChildIndex = PriorityQueue.getIndexOfRightChild({ index });
 
@@ -98,11 +98,11 @@ class PriorityQueue<TItem> {
     if (leftChildItemPriority <= rightChildItemPriority) {
       this.items[leftChildIndex] = item;
       this.items[index] = leftChildItem;
-      this.sink({ item, index: leftChildIndex });
+      this.repairDown({ item, index: leftChildIndex });
     } else {
       this.items[rightChildIndex] = item;
       this.items[index] = rightChildItem;
-      this.sink({ item, index: rightChildIndex });
+      this.repairDown({ item, index: rightChildIndex });
     }
   }
 
@@ -122,7 +122,7 @@ class PriorityQueue<TItem> {
     const enqueueIndex = this.items.length;
 
     this.items[enqueueIndex] = item;
-    this.swim({ item, index: enqueueIndex });
+    this.repairUp({ item, index: enqueueIndex });
   }
 
   public async dequeue ({ item }: { item: TItem }): Promise<void> {
@@ -144,9 +144,9 @@ class PriorityQueue<TItem> {
     const lastItemPriority = this.getPriority(lastItem!);
 
     if (lastItemPriority < itemPriority) {
-      this.swim({ item: lastItem!, index });
+      this.repairUp({ item: lastItem!, index });
     } else {
-      this.sink({ item: lastItem!, index });
+      this.repairDown({ item: lastItem!, index });
     }
   }
 
@@ -157,11 +157,11 @@ class PriorityQueue<TItem> {
       return;
     }
 
-    // Run both, swim and sink. One of them may take action. Instead of trying
-    // to detect which one to call, simply call both, and one of them will do
-    // its job if necessary.
-    this.swim({ item, index });
-    this.sink({ item, index });
+    // Run both, repairUp and repairDown. One of them may take action. Instead
+    // of trying to detect which one to call, simply call both, and one of them
+    // will do its job if necessary.
+    this.repairUp({ item, index });
+    this.repairDown({ item, index });
   }
 }
 

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -1,8 +1,5 @@
 import { GetPriority } from './GetPriority';
 
-// Hashtable als Index für effizientes Remove (um Linear Scan wegzubekommen)
-// => Key -> Liste(Array-Index)
-
 class PriorityQueue<TItem> {
   protected items: (TItem | undefined)[];
 

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -142,15 +142,7 @@ class PriorityQueue<TItem> {
     }
 
     this.items[index] = lastItem;
-
-    const itemPriority = this.getPriority(item);
-    const lastItemPriority = this.getPriority(lastItem!);
-
-    if (lastItemPriority < itemPriority) {
-      this.repairUp({ item: lastItem!, index });
-    } else {
-      this.repairDown({ item: lastItem!, index });
-    }
+    this.repairDown({ item: lastItem!, index });
   }
 
   public async rebalance ({ item }: { item: TItem }): Promise<void> {

--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -128,7 +128,7 @@ class PriorityQueue<TItem> {
     this.repairUp({ item, index: enqueueIndex });
   }
 
-  public async dequeue ({ item }: { item: TItem }): Promise<void> {
+  public async remove ({ item }: { item: TItem }): Promise<void> {
     const index = this.getIndexOfItem({ item });
 
     if (index === undefined) {
@@ -143,6 +143,18 @@ class PriorityQueue<TItem> {
 
     this.items[index] = lastItem;
     this.repairDown({ item: lastItem!, index });
+  }
+
+  public async dequeue (): Promise<TItem | undefined> {
+    const nextItem = await this.getNextItem();
+
+    if (!nextItem) {
+      return;
+    }
+
+    await this.remove({ item: nextItem });
+
+    return nextItem;
   }
 
   public async repair ({ item }: { item: TItem }): Promise<void> {

--- a/lib/common/data/PriorityQueue/index.ts
+++ b/lib/common/data/PriorityQueue/index.ts
@@ -1,0 +1,3 @@
+import { PriorityQueue } from './PriorityQueue';
+
+export { PriorityQueue };

--- a/test/unit/common/data/PriorityQueueTests.ts
+++ b/test/unit/common/data/PriorityQueueTests.ts
@@ -41,15 +41,15 @@ suite('PriorityQueue', (): void => {
     });
   });
 
-  suite('getHeap', (): void => {
+  suite('values', (): void => {
     test('returns an empty array if no items have been enqueued.', async (): Promise<void> => {
-      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+      assert.that(await priorityQueue.values()).is.equalTo([]);
     });
 
     test('returns the heap array if items have been enqueued.', async (): Promise<void> => {
       await priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 23 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 23 ]);
     });
   });
 
@@ -57,7 +57,7 @@ suite('PriorityQueue', (): void => {
     test('enqueues the first item as root.', async (): Promise<void> => {
       await priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 23 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 23 ]);
     });
 
     test('enqueues with respect to the heap structure.', async (): Promise<void> => {
@@ -67,7 +67,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueue.enqueue({ item: 5 });
       await priorityQueue.enqueue({ item: 12 });
 
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 23, 42, 12 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 23, 42, 12 ]);
     });
   });
 
@@ -76,7 +76,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueue.enqueue({ item: 23 });
       await priorityQueue.dequeue({ item: 23 });
 
-      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+      assert.that(await priorityQueue.values()).is.equalTo([]);
     });
 
     test('dequeues with respect to the heap structure.', async (): Promise<void> => {
@@ -87,19 +87,19 @@ suite('PriorityQueue', (): void => {
       await priorityQueue.enqueue({ item: 12 });
 
       await priorityQueue.dequeue({ item: 23 });
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 12, 42 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12, 42 ]);
 
       await priorityQueue.dequeue({ item: 42 });
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 12 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12 ]);
 
       await priorityQueue.dequeue({ item: 7 });
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 12 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 5, 12 ]);
 
       await priorityQueue.dequeue({ item: 5 });
-      assert.that(await priorityQueue.getHeap()).is.equalTo([ 12 ]);
+      assert.that(await priorityQueue.values()).is.equalTo([ 12 ]);
 
       await priorityQueue.dequeue({ item: 12 });
-      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+      assert.that(await priorityQueue.values()).is.equalTo([]);
     });
   });
 
@@ -126,7 +126,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueueComplex.rebalance({ item: itemToRebalance });
 
       assert.that(
-        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+        (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 7, 5, 23, 42, 12 ]);
     });
 
@@ -135,7 +135,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueueComplex.rebalance({ item: itemToRebalance });
 
       assert.that(
-        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+        (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 5, 12, 23, 42, 7 ]);
     });
 
@@ -146,7 +146,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueueComplex.rebalance({ item: rootItem! });
 
       assert.that(
-        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+        (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 5, 7, 23, 42, 12 ]);
     });
 
@@ -157,7 +157,7 @@ suite('PriorityQueue', (): void => {
       await priorityQueueComplex.rebalance({ item: rootItem! });
 
       assert.that(
-        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+        (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 7, 12, 23, 42, 5 ]);
     });
   });

--- a/test/unit/common/data/PriorityQueueTests.ts
+++ b/test/unit/common/data/PriorityQueueTests.ts
@@ -21,9 +21,9 @@ suite('PriorityQueue', (): void => {
       assert.that(await priorityQueue.isEmpty()).is.false();
     });
 
-    test('returns true if all items have been dequeued.', async (): Promise<void> => {
+    test('returns true if all items have been removed.', async (): Promise<void> => {
       await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.dequeue({ item: 23 });
+      await priorityQueue.remove({ item: 23 });
 
       assert.that(await priorityQueue.isEmpty()).is.true();
     });
@@ -71,35 +71,63 @@ suite('PriorityQueue', (): void => {
     });
   });
 
-  suite('dequeue', (): void => {
-    test('dequeues the root item if there is only one item.', async (): Promise<void> => {
+  suite('remove', (): void => {
+    test('removes the root item if there is only one item.', async (): Promise<void> => {
       await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.dequeue({ item: 23 });
+      await priorityQueue.remove({ item: 23 });
 
       assert.that(await priorityQueue.values()).is.equalTo([]);
     });
 
-    test('dequeues with respect to the heap structure.', async (): Promise<void> => {
+    test('removes with respect to the heap structure.', async (): Promise<void> => {
       await priorityQueue.enqueue({ item: 23 });
       await priorityQueue.enqueue({ item: 42 });
       await priorityQueue.enqueue({ item: 7 });
       await priorityQueue.enqueue({ item: 5 });
       await priorityQueue.enqueue({ item: 12 });
 
-      await priorityQueue.dequeue({ item: 23 });
+      await priorityQueue.remove({ item: 23 });
       assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12, 42 ]);
 
-      await priorityQueue.dequeue({ item: 42 });
+      await priorityQueue.remove({ item: 42 });
       assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12 ]);
 
-      await priorityQueue.dequeue({ item: 7 });
+      await priorityQueue.remove({ item: 7 });
       assert.that(await priorityQueue.values()).is.equalTo([ 5, 12 ]);
 
-      await priorityQueue.dequeue({ item: 5 });
+      await priorityQueue.remove({ item: 5 });
       assert.that(await priorityQueue.values()).is.equalTo([ 12 ]);
 
-      await priorityQueue.dequeue({ item: 12 });
+      await priorityQueue.remove({ item: 12 });
       assert.that(await priorityQueue.values()).is.equalTo([]);
+    });
+  });
+
+  suite('dequeue', (): void => {
+    test('returns undefined if there is no next item.', async (): Promise<void> => {
+      assert.that(await priorityQueue.dequeue()).is.undefined();
+    });
+
+    test('removes and returns the root item if there is only one item.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+
+      const nextItem = await priorityQueue.dequeue();
+
+      assert.that(nextItem).is.equalTo(23);
+      assert.that(await priorityQueue.values()).is.equalTo([]);
+    });
+
+    test('removes and returns the next item if there are more items.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+      await priorityQueue.enqueue({ item: 42 });
+      await priorityQueue.enqueue({ item: 7 });
+      await priorityQueue.enqueue({ item: 5 });
+      await priorityQueue.enqueue({ item: 12 });
+
+      const nextItem = await priorityQueue.dequeue();
+
+      assert.that(nextItem).is.equalTo(5);
+      assert.that(await priorityQueue.values()).is.equalTo([ 7, 12, 23, 42 ]);
     });
   });
 

--- a/test/unit/common/data/PriorityQueueTests.ts
+++ b/test/unit/common/data/PriorityQueueTests.ts
@@ -103,8 +103,8 @@ suite('PriorityQueue', (): void => {
     });
   });
 
-  suite('rebalance', (): void => {
-    let itemToRebalance: { value: number; priority: number },
+  suite('repair', (): void => {
+    let itemToRepair: { value: number; priority: number },
         priorityQueueComplex: PriorityQueue<{ value: number; priority: number }>;
 
     setup(async (): Promise<void> => {
@@ -112,49 +112,49 @@ suite('PriorityQueue', (): void => {
         getPriority: (item): number => item.priority
       });
 
-      itemToRebalance = { value: 7, priority: 7 };
+      itemToRepair = { value: 7, priority: 7 };
 
       await priorityQueueComplex.enqueue({ item: { value: 23, priority: 23 }});
       await priorityQueueComplex.enqueue({ item: { value: 42, priority: 42 }});
-      await priorityQueueComplex.enqueue({ item: itemToRebalance });
+      await priorityQueueComplex.enqueue({ item: itemToRepair });
       await priorityQueueComplex.enqueue({ item: { value: 5, priority: 5 }});
       await priorityQueueComplex.enqueue({ item: { value: 12, priority: 12 }});
     });
 
-    test('rebalances the heap structure if a priority becomes smaller.', async (): Promise<void> => {
-      itemToRebalance.priority = 1;
-      await priorityQueueComplex.rebalance({ item: itemToRebalance });
+    test('repairs the heap structure if a priority becomes smaller.', async (): Promise<void> => {
+      itemToRepair.priority = 1;
+      await priorityQueueComplex.repair({ item: itemToRepair });
 
       assert.that(
         (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 7, 5, 23, 42, 12 ]);
     });
 
-    test('rebalances the heap structure if a priority becomes larger.', async (): Promise<void> => {
-      itemToRebalance.priority = 99;
-      await priorityQueueComplex.rebalance({ item: itemToRebalance });
+    test('repairs the heap structure if a priority becomes larger.', async (): Promise<void> => {
+      itemToRepair.priority = 99;
+      await priorityQueueComplex.repair({ item: itemToRepair });
 
       assert.that(
         (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 5, 12, 23, 42, 7 ]);
     });
 
-    test('rebalances the heap structure if the priority of the root item becomes smaller.', async (): Promise<void> => {
+    test('repairs the heap structure if the priority of the root item becomes smaller.', async (): Promise<void> => {
       const rootItem = await priorityQueueComplex.getNextItem();
 
       rootItem!.priority = 1;
-      await priorityQueueComplex.rebalance({ item: rootItem! });
+      await priorityQueueComplex.repair({ item: rootItem! });
 
       assert.that(
         (await priorityQueueComplex.values()).map((item): number => item!.value)
       ).is.equalTo([ 5, 7, 23, 42, 12 ]);
     });
 
-    test('rebalances the heap structure if the priority of the root item becomes larger.', async (): Promise<void> => {
+    test('repairs the heap structure if the priority of the root item becomes larger.', async (): Promise<void> => {
       const rootItem = await priorityQueueComplex.getNextItem();
 
       rootItem!.priority = 99;
-      await priorityQueueComplex.rebalance({ item: rootItem! });
+      await priorityQueueComplex.repair({ item: rootItem! });
 
       assert.that(
         (await priorityQueueComplex.values()).map((item): number => item!.value)

--- a/test/unit/common/data/PriorityQueueTests.ts
+++ b/test/unit/common/data/PriorityQueueTests.ts
@@ -1,0 +1,164 @@
+import { assert } from 'assertthat';
+import { PriorityQueue } from '../../../../lib/common/data/PriorityQueue';
+
+suite('PriorityQueue', (): void => {
+  let priorityQueue: PriorityQueue<number>;
+
+  setup(async (): Promise<void> => {
+    priorityQueue = new PriorityQueue<number>({
+      getPriority: (item): number => item
+    });
+  });
+
+  suite('isEmpty', (): void => {
+    test('returns true for a new instance.', async (): Promise<void> => {
+      assert.that(await priorityQueue.isEmpty()).is.true();
+    });
+
+    test('returns false if items have been enqueued.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+
+      assert.that(await priorityQueue.isEmpty()).is.false();
+    });
+
+    test('returns true if all items have been dequeued.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+      await priorityQueue.dequeue({ item: 23 });
+
+      assert.that(await priorityQueue.isEmpty()).is.true();
+    });
+  });
+
+  suite('getNextItem', (): void => {
+    test('returns undefined if there is no next item.', async (): Promise<void> => {
+      assert.that(await priorityQueue.getNextItem()).is.undefined();
+    });
+
+    test('returns the root item if there are items.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+
+      assert.that(await priorityQueue.getNextItem()).is.equalTo(23);
+    });
+  });
+
+  suite('getHeap', (): void => {
+    test('returns an empty array if no items have been enqueued.', async (): Promise<void> => {
+      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+    });
+
+    test('returns the heap array if items have been enqueued.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 23 ]);
+    });
+  });
+
+  suite('enqueue', (): void => {
+    test('enqueues the first item as root.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 23 ]);
+    });
+
+    test('enqueues with respect to the heap structure.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+      await priorityQueue.enqueue({ item: 42 });
+      await priorityQueue.enqueue({ item: 7 });
+      await priorityQueue.enqueue({ item: 5 });
+      await priorityQueue.enqueue({ item: 12 });
+
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 23, 42, 12 ]);
+    });
+  });
+
+  suite('dequeue', (): void => {
+    test('dequeues the root item if there is only one item.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+      await priorityQueue.dequeue({ item: 23 });
+
+      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+    });
+
+    test('dequeues with respect to the heap structure.', async (): Promise<void> => {
+      await priorityQueue.enqueue({ item: 23 });
+      await priorityQueue.enqueue({ item: 42 });
+      await priorityQueue.enqueue({ item: 7 });
+      await priorityQueue.enqueue({ item: 5 });
+      await priorityQueue.enqueue({ item: 12 });
+
+      await priorityQueue.dequeue({ item: 23 });
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 12, 42 ]);
+
+      await priorityQueue.dequeue({ item: 42 });
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 7, 12 ]);
+
+      await priorityQueue.dequeue({ item: 7 });
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 5, 12 ]);
+
+      await priorityQueue.dequeue({ item: 5 });
+      assert.that(await priorityQueue.getHeap()).is.equalTo([ 12 ]);
+
+      await priorityQueue.dequeue({ item: 12 });
+      assert.that(await priorityQueue.getHeap()).is.equalTo([]);
+    });
+  });
+
+  suite('rebalance', (): void => {
+    let itemToRebalance: { value: number; priority: number },
+        priorityQueueComplex: PriorityQueue<{ value: number; priority: number }>;
+
+    setup(async (): Promise<void> => {
+      priorityQueueComplex = new PriorityQueue<{ value: number; priority: number }>({
+        getPriority: (item): number => item.priority
+      });
+
+      itemToRebalance = { value: 7, priority: 7 };
+
+      await priorityQueueComplex.enqueue({ item: { value: 23, priority: 23 }});
+      await priorityQueueComplex.enqueue({ item: { value: 42, priority: 42 }});
+      await priorityQueueComplex.enqueue({ item: itemToRebalance });
+      await priorityQueueComplex.enqueue({ item: { value: 5, priority: 5 }});
+      await priorityQueueComplex.enqueue({ item: { value: 12, priority: 12 }});
+    });
+
+    test('rebalances the heap structure if a priority becomes smaller.', async (): Promise<void> => {
+      itemToRebalance.priority = 1;
+      await priorityQueueComplex.rebalance({ item: itemToRebalance });
+
+      assert.that(
+        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+      ).is.equalTo([ 7, 5, 23, 42, 12 ]);
+    });
+
+    test('rebalances the heap structure if a priority becomes larger.', async (): Promise<void> => {
+      itemToRebalance.priority = 99;
+      await priorityQueueComplex.rebalance({ item: itemToRebalance });
+
+      assert.that(
+        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+      ).is.equalTo([ 5, 12, 23, 42, 7 ]);
+    });
+
+    test('rebalances the heap structure if the priority of the root item becomes smaller.', async (): Promise<void> => {
+      const rootItem = await priorityQueueComplex.getNextItem();
+
+      rootItem!.priority = 1;
+      await priorityQueueComplex.rebalance({ item: rootItem! });
+
+      assert.that(
+        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+      ).is.equalTo([ 5, 7, 23, 42, 12 ]);
+    });
+
+    test('rebalances the heap structure if the priority of the root item becomes larger.', async (): Promise<void> => {
+      const rootItem = await priorityQueueComplex.getNextItem();
+
+      rootItem!.priority = 99;
+      await priorityQueueComplex.rebalance({ item: rootItem! });
+
+      assert.that(
+        (await priorityQueueComplex.getHeap()).map((item): number => item!.value)
+      ).is.equalTo([ 7, 12, 23, 42, 5 ]);
+    });
+  });
+});


### PR DESCRIPTION
Hi @yeldiRium 👋 

As announced on Slack, I have found the time to implement a first draft of an in-memory priority queue this weekend.

There's still room for improvement (e.g., a lookup index for efficiently accessing individual elements is missing), and also I'm not perfectly sure about the API, but the basic implementation seems to work, and it is tested 😊 

Could you please have a look at it, and decide, whether you already would like to squash / merge it, or if we should take further steps first before doing this? If you decide to squash / merge, feel free to do so 😊 