### PR TITLE
Turn asynchronous functions to synchronous ones.

### DIFF
--- a/lib/common/data/PriorityQueue/PriorityQueue.ts
+++ b/lib/common/data/PriorityQueue/PriorityQueue.ts
@@ -109,26 +109,26 @@ class PriorityQueue<TItem> {
     }
   }
 
-  public async isEmpty (): Promise<boolean> {
+  public isEmpty (): boolean {
     return this.items.length === 0;
   }
 
-  public async getNextItem (): Promise<TItem | undefined> {
+  public getNextItem (): TItem | undefined {
     return this.items[0];
   }
 
-  public async values (): Promise<(TItem | undefined)[]> {
+  public values (): (TItem | undefined)[] {
     return this.items;
   }
 
-  public async enqueue ({ item }: { item: TItem }): Promise<void> {
+  public enqueue ({ item }: { item: TItem }): void {
     const enqueueIndex = this.items.length;
 
     this.items[enqueueIndex] = item;
     this.repairUp({ item, index: enqueueIndex });
   }
 
-  public async remove ({ item }: { item: TItem }): Promise<void> {
+  public remove ({ item }: { item: TItem }): void {
     const index = this.getIndexOfItem({ item });
 
     if (index === undefined) {
@@ -145,19 +145,19 @@ class PriorityQueue<TItem> {
     this.repairDown({ item: lastItem!, index });
   }
 
-  public async dequeue (): Promise<TItem | undefined> {
-    const nextItem = await this.getNextItem();
+  public dequeue (): TItem | undefined {
+    const nextItem = this.getNextItem();
 
     if (!nextItem) {
       return;
     }
 
-    await this.remove({ item: nextItem });
+    this.remove({ item: nextItem });
 
     return nextItem;
   }
 
-  public async repair ({ item }: { item: TItem }): Promise<void> {
+  public repair ({ item }: { item: TItem }): void {
     const index = this.getIndexOfItem({ item });
 
     if (index === undefined) {

--- a/test/unit/common/data/PriorityQueueTests.ts
+++ b/test/unit/common/data/PriorityQueueTests.ts
@@ -12,122 +12,122 @@ suite('PriorityQueue', (): void => {
 
   suite('isEmpty', (): void => {
     test('returns true for a new instance.', async (): Promise<void> => {
-      assert.that(await priorityQueue.isEmpty()).is.true();
+      assert.that(priorityQueue.isEmpty()).is.true();
     });
 
     test('returns false if items have been enqueued.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.isEmpty()).is.false();
+      assert.that(priorityQueue.isEmpty()).is.false();
     });
 
     test('returns true if all items have been removed.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.remove({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
+      priorityQueue.remove({ item: 23 });
 
-      assert.that(await priorityQueue.isEmpty()).is.true();
+      assert.that(priorityQueue.isEmpty()).is.true();
     });
   });
 
   suite('getNextItem', (): void => {
     test('returns undefined if there is no next item.', async (): Promise<void> => {
-      assert.that(await priorityQueue.getNextItem()).is.undefined();
+      assert.that(priorityQueue.getNextItem()).is.undefined();
     });
 
     test('returns the root item if there are items.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.getNextItem()).is.equalTo(23);
+      assert.that(priorityQueue.getNextItem()).is.equalTo(23);
     });
   });
 
   suite('values', (): void => {
     test('returns an empty array if no items have been enqueued.', async (): Promise<void> => {
-      assert.that(await priorityQueue.values()).is.equalTo([]);
+      assert.that(priorityQueue.values()).is.equalTo([]);
     });
 
     test('returns the heap array if items have been enqueued.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.values()).is.equalTo([ 23 ]);
+      assert.that(priorityQueue.values()).is.equalTo([ 23 ]);
     });
   });
 
   suite('enqueue', (): void => {
     test('enqueues the first item as root.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
 
-      assert.that(await priorityQueue.values()).is.equalTo([ 23 ]);
+      assert.that(priorityQueue.values()).is.equalTo([ 23 ]);
     });
 
     test('enqueues with respect to the heap structure.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.enqueue({ item: 42 });
-      await priorityQueue.enqueue({ item: 7 });
-      await priorityQueue.enqueue({ item: 5 });
-      await priorityQueue.enqueue({ item: 12 });
+      priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 42 });
+      priorityQueue.enqueue({ item: 7 });
+      priorityQueue.enqueue({ item: 5 });
+      priorityQueue.enqueue({ item: 12 });
 
-      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 23, 42, 12 ]);
+      assert.that(priorityQueue.values()).is.equalTo([ 5, 7, 23, 42, 12 ]);
     });
   });
 
   suite('remove', (): void => {
     test('removes the root item if there is only one item.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.remove({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
+      priorityQueue.remove({ item: 23 });
 
-      assert.that(await priorityQueue.values()).is.equalTo([]);
+      assert.that(priorityQueue.values()).is.equalTo([]);
     });
 
     test('removes with respect to the heap structure.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.enqueue({ item: 42 });
-      await priorityQueue.enqueue({ item: 7 });
-      await priorityQueue.enqueue({ item: 5 });
-      await priorityQueue.enqueue({ item: 12 });
+      priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 42 });
+      priorityQueue.enqueue({ item: 7 });
+      priorityQueue.enqueue({ item: 5 });
+      priorityQueue.enqueue({ item: 12 });
 
-      await priorityQueue.remove({ item: 23 });
-      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12, 42 ]);
+      priorityQueue.remove({ item: 23 });
+      assert.that(priorityQueue.values()).is.equalTo([ 5, 7, 12, 42 ]);
 
-      await priorityQueue.remove({ item: 42 });
-      assert.that(await priorityQueue.values()).is.equalTo([ 5, 7, 12 ]);
+      priorityQueue.remove({ item: 42 });
+      assert.that(priorityQueue.values()).is.equalTo([ 5, 7, 12 ]);
 
-      await priorityQueue.remove({ item: 7 });
-      assert.that(await priorityQueue.values()).is.equalTo([ 5, 12 ]);
+      priorityQueue.remove({ item: 7 });
+      assert.that(priorityQueue.values()).is.equalTo([ 5, 12 ]);
 
-      await priorityQueue.remove({ item: 5 });
-      assert.that(await priorityQueue.values()).is.equalTo([ 12 ]);
+      priorityQueue.remove({ item: 5 });
+      assert.that(priorityQueue.values()).is.equalTo([ 12 ]);
 
-      await priorityQueue.remove({ item: 12 });
-      assert.that(await priorityQueue.values()).is.equalTo([]);
+      priorityQueue.remove({ item: 12 });
+      assert.that(priorityQueue.values()).is.equalTo([]);
     });
   });
 
   suite('dequeue', (): void => {
     test('returns undefined if there is no next item.', async (): Promise<void> => {
-      assert.that(await priorityQueue.dequeue()).is.undefined();
+      assert.that(priorityQueue.dequeue()).is.undefined();
     });
 
     test('removes and returns the root item if there is only one item.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 23 });
 
-      const nextItem = await priorityQueue.dequeue();
+      const nextItem = priorityQueue.dequeue();
 
       assert.that(nextItem).is.equalTo(23);
-      assert.that(await priorityQueue.values()).is.equalTo([]);
+      assert.that(priorityQueue.values()).is.equalTo([]);
     });
 
     test('removes and returns the next item if there are more items.', async (): Promise<void> => {
-      await priorityQueue.enqueue({ item: 23 });
-      await priorityQueue.enqueue({ item: 42 });
-      await priorityQueue.enqueue({ item: 7 });
-      await priorityQueue.enqueue({ item: 5 });
-      await priorityQueue.enqueue({ item: 12 });
+      priorityQueue.enqueue({ item: 23 });
+      priorityQueue.enqueue({ item: 42 });
+      priorityQueue.enqueue({ item: 7 });
+      priorityQueue.enqueue({ item: 5 });
+      priorityQueue.enqueue({ item: 12 });
 
-      const nextItem = await priorityQueue.dequeue();
+      const nextItem = priorityQueue.dequeue();
 
       assert.that(nextItem).is.equalTo(5);
-      assert.that(await priorityQueue.values()).is.equalTo([ 7, 12, 23, 42 ]);
+      assert.that(priorityQueue.values()).is.equalTo([ 7, 12, 23, 42 ]);
     });
   });
 
@@ -142,50 +142,50 @@ suite('PriorityQueue', (): void => {
 
       itemToRepair = { value: 7, priority: 7 };
 
-      await priorityQueueComplex.enqueue({ item: { value: 23, priority: 23 }});
-      await priorityQueueComplex.enqueue({ item: { value: 42, priority: 42 }});
-      await priorityQueueComplex.enqueue({ item: itemToRepair });
-      await priorityQueueComplex.enqueue({ item: { value: 5, priority: 5 }});
-      await priorityQueueComplex.enqueue({ item: { value: 12, priority: 12 }});
+      priorityQueueComplex.enqueue({ item: { value: 23, priority: 23 }});
+      priorityQueueComplex.enqueue({ item: { value: 42, priority: 42 }});
+      priorityQueueComplex.enqueue({ item: itemToRepair });
+      priorityQueueComplex.enqueue({ item: { value: 5, priority: 5 }});
+      priorityQueueComplex.enqueue({ item: { value: 12, priority: 12 }});
     });
 
     test('repairs the heap structure if a priority becomes smaller.', async (): Promise<void> => {
       itemToRepair.priority = 1;
-      await priorityQueueComplex.repair({ item: itemToRepair });
+      priorityQueueComplex.repair({ item: itemToRepair });
 
       assert.that(
-        (await priorityQueueComplex.values()).map((item): number => item!.value)
+        priorityQueueComplex.values().map((item): number => item!.value)
       ).is.equalTo([ 7, 5, 23, 42, 12 ]);
     });
 
     test('repairs the heap structure if a priority becomes larger.', async (): Promise<void> => {
       itemToRepair.priority = 99;
-      await priorityQueueComplex.repair({ item: itemToRepair });
+      priorityQueueComplex.repair({ item: itemToRepair });
 
       assert.that(
-        (await priorityQueueComplex.values()).map((item): number => item!.value)
+        priorityQueueComplex.values().map((item): number => item!.value)
       ).is.equalTo([ 5, 12, 23, 42, 7 ]);
     });
 
     test('repairs the heap structure if the priority of the root item becomes smaller.', async (): Promise<void> => {
-      const rootItem = await priorityQueueComplex.getNextItem();
+      const rootItem = priorityQueueComplex.getNextItem();
 
       rootItem!.priority = 1;
-      await priorityQueueComplex.repair({ item: rootItem! });
+      priorityQueueComplex.repair({ item: rootItem! });
 
       assert.that(
-        (await priorityQueueComplex.values()).map((item): number => item!.value)
+        priorityQueueComplex.values().map((item): number => item!.value)
       ).is.equalTo([ 5, 7, 23, 42, 12 ]);
     });
 
     test('repairs the heap structure if the priority of the root item becomes larger.', async (): Promise<void> => {
-      const rootItem = await priorityQueueComplex.getNextItem();
+      const rootItem = priorityQueueComplex.getNextItem();
 
       rootItem!.priority = 99;
-      await priorityQueueComplex.repair({ item: rootItem! });
+      priorityQueueComplex.repair({ item: rootItem! });
 
       assert.that(
-        (await priorityQueueComplex.values()).map((item): number => item!.value)
+        priorityQueueComplex.values().map((item): number => item!.value)
       ).is.equalTo([ 7, 12, 23, 42, 5 ]);
     });
   });


### PR DESCRIPTION
Hey @yeldiRium 😊 

As announced on Slack, I think it's a) a good idea to keep the priority queue generic, and b) to turn the asynchronous functions to synchronous ones.

For a) we didn't need to do anything, for b) I have created this PR.

If you're fine with it, can you please squash / merge it?