### PR TITLE
Fix get ports.

### DIFF
--- a/lib/common/utils/network/getAvailablePort.ts
+++ b/lib/common/utils/network/getAvailablePort.ts
@@ -1,31 +1,9 @@
-import { sleep } from '../sleep';
-import { AddressInfo, createServer } from 'net';
+import { getAvailablePorts } from './getAvailablePorts';
 
 const getAvailablePort = async function (): Promise<number> {
-  return new Promise((resolve, reject): void => {
-    const server = createServer();
+  const [ availablePort ] = await getAvailablePorts({ count: 1 });
 
-    let port: number;
-
-    server.once('listening', (): void => {
-      ({ port } = (server.address() as AddressInfo));
-
-      server.close(async (err): Promise<void> => {
-        if (err) {
-          return reject(err);
-        }
-
-        await sleep({ ms: 500 });
-        resolve(port);
-      });
-    });
-
-    server.once('error', (err): void => {
-      reject(err);
-    });
-
-    server.listen(0, '127.0.0.1');
-  });
+  return availablePort;
 };
 
 export { getAvailablePort };

--- a/lib/common/utils/network/getAvailablePorts.ts
+++ b/lib/common/utils/network/getAvailablePorts.ts
@@ -1,0 +1,67 @@
+import { AddressInfo, createServer, Server } from 'net';
+
+const servers: Record<number, Server | undefined> = {};
+
+const lockPort = async function (): Promise<number> {
+  return new Promise((resolve, reject): void => {
+    const server = createServer();
+
+    let port: number;
+
+    server.once('listening', (): void => {
+      ({ port } = (server.address() as AddressInfo));
+
+      servers[port] = server;
+
+      resolve(port);
+    });
+
+    server.once('error', (err): void => {
+      reject(err);
+    });
+
+    server.listen(0, '127.0.0.1');
+  });
+};
+
+const releasePort = async function ({ port }: { port: number }): Promise<void> {
+  const server = servers[port];
+
+  if (!server) {
+    throw new Error(`Port ${port} is not locked.`);
+  }
+
+  await new Promise((resolve, reject): void => {
+    server.close(async (err): Promise<void> => {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve();
+    });
+  });
+};
+
+const getAvailablePorts = async function ({ count }: {
+  count: number;
+}): Promise<number[]> {
+  const availablePorts = [];
+
+  for (let i = 0; i < count; i++) {
+    availablePorts.push(await lockPort());
+  }
+
+  for (const availablePort of availablePorts) {
+    await releasePort({ port: availablePort });
+  }
+
+  return availablePorts;
+};
+
+const getAvailablePort = async function (): Promise<number> {
+  const [ availablePort ] = await getAvailablePorts({ count: 1 });
+
+  return availablePort;
+};
+
+export { getAvailablePorts, getAvailablePort };

--- a/test/runtime/microservice/processes/command/processTests.ts
+++ b/test/runtime/microservice/processes/command/processTests.ts
@@ -16,15 +16,15 @@ suite('command', function (): void {
   const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
 
   let commandReceivedByDispatcherServer: object | undefined,
+      dispatcherServerPort: number,
       port: number,
-      portDispatcherServer: number,
       stopProcess: (() => Promise<void>) | undefined;
 
   setup(async (): Promise<void> => {
-    [ port, portDispatcherServer ] = await getAvailablePorts({ count: 2 });
+    [ port, dispatcherServerPort ] = await getAvailablePorts({ count: 2 });
 
     await startCatchAllServer({
-      port: portDispatcherServer,
+      port: dispatcherServerPort,
       onRequest (req, res): void {
         commandReceivedByDispatcherServer = req.body;
         res.status(200).end();
@@ -39,7 +39,7 @@ suite('command', function (): void {
         APPLICATION_DIRECTORY: applicationDirectory,
         PORT: String(port),
         DISPATCHER_SERVER_HOSTNAME: 'localhost',
-        DISPATCHER_SERVER_PORT: String(portDispatcherServer),
+        DISPATCHER_SERVER_PORT: String(dispatcherServerPort),
         IDENTITY_PROVIDERS: `[{"issuer": "https://token.invalid", "certificate": "${certificateDirectory}"}]`
       }
     });

--- a/test/runtime/microservice/processes/command/processTests.ts
+++ b/test/runtime/microservice/processes/command/processTests.ts
@@ -1,6 +1,6 @@
 import { assert } from 'assertthat';
 import { Command } from '../../../../../lib/common/elements/Command';
-import { getAvailablePort } from '../../../../../lib/common/utils/network/getAvailablePort';
+import { getAvailablePorts } from '../../../../../lib/common/utils/network/getAvailablePorts';
 import { getTestApplicationDirectory } from '../../../../shared/applications/getTestApplicationDirectory';
 import path from 'path';
 import { startCatchAllServer } from '../../../../shared/runtime/startCatchAllServer';
@@ -17,10 +17,11 @@ suite('command', function (): void {
 
   let commandReceivedByDispatcherServer: object | undefined,
       port: number,
+      portDispatcherServer: number,
       stopProcess: (() => Promise<void>) | undefined;
 
   setup(async (): Promise<void> => {
-    const portDispatcherServer = await getAvailablePort();
+    [ port, portDispatcherServer ] = await getAvailablePorts({ count: 2 });
 
     await startCatchAllServer({
       port: portDispatcherServer,
@@ -29,8 +30,6 @@ suite('command', function (): void {
         res.status(200).end();
       }
     });
-
-    port = await getAvailablePort();
 
     stopProcess = await startProcess({
       runtime: 'microservice',

--- a/test/runtime/microservice/processes/dispatcher/processTests.js
+++ b/test/runtime/microservice/processes/dispatcher/processTests.js
@@ -6,7 +6,7 @@ const assert = require('assertthat').default,
       uuid = require('uuidv4');
 
 const { CommandInternal } = require('../../../../../common/elements'),
-      getAvailablePort = require('../../../../../common/utils/network/getAvailablePort'),
+      getAvailablePorts = require('../../../../../common/utils/network/getAvailablePorts'),
       startCatchAllServer = require('../../../../shared/runtime/startCatchAllServer'),
       startProcess = require('../../../../shared/runtime/startProcess');
 
@@ -15,12 +15,13 @@ suite('dispatcher', function () {
 
   let commandsReceivedByDomainServer,
       port,
+      portDomainServer,
       stopProcess;
 
   setup(async () => {
     commandsReceivedByDomainServer = [];
 
-    const portDomainServer = await getAvailablePort();
+    [ port, portDomainServer ] = await getAvailablePorts({ count: 2 });
 
     await startCatchAllServer({
       port: portDomainServer,
@@ -29,8 +30,6 @@ suite('dispatcher', function () {
         res.status(200).end();
       }
     });
-
-    port = await getAvailablePort();
 
     stopProcess = await startProcess({
       runtime: 'microservice',

--- a/test/runtime/microservice/processes/dispatcher/processTests.js
+++ b/test/runtime/microservice/processes/dispatcher/processTests.js
@@ -5,7 +5,7 @@ const assert = require('assertthat').default,
       uuid = require('uuidv4');
 
 const { CommandInternal } = require('../../../../../common/elements'),
-      getAvailablePort = require('../../../../../common/utils/network/getAvailablePort'),
+      getAvailablePorts = require('../../../../../common/utils/network/getAvailablePorts'),
       sleep = require('../../../../../common/utils/sleep'),
       startCatchAllServer = require('../../../../shared/runtime/startCatchAllServer'),
       startProcess = require('../../../../shared/runtime/startProcess');

--- a/test/runtime/microservice/processes/dispatcher/processTests.js
+++ b/test/runtime/microservice/processes/dispatcher/processTests.js
@@ -14,17 +14,17 @@ suite('dispatcher', function () {
   this.timeout(10 * 1000);
 
   let commandsReceivedByDomainServer,
+      domainServerPort,
       port,
-      portDomainServer,
       stopProcess;
 
   setup(async () => {
     commandsReceivedByDomainServer = [];
 
-    [ port, portDomainServer ] = await getAvailablePorts({ count: 2 });
+    [ port, domainServerPort ] = await getAvailablePorts({ count: 2 });
 
     await startCatchAllServer({
-      port: portDomainServer,
+      port: domainServerPort,
       onRequest (req, res) {
         commandsReceivedByDomainServer.push(req.body);
         res.status(200).end();
@@ -38,7 +38,7 @@ suite('dispatcher', function () {
       env: {
         PORT: port,
         DOMAIN_SERVER_HOSTNAME: 'localhost',
-        DOMAIN_SERVER_PORT: portDomainServer
+        DOMAIN_SERVER_PORT: domainServerPort
       }
     });
   });

--- a/test/runtime/microservice/processes/domainEvent/processTests.ts
+++ b/test/runtime/microservice/processes/domainEvent/processTests.ts
@@ -17,20 +17,20 @@ suite('domain event', function (): void {
 
   const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
 
-  let portPublisher: number,
-      portReceiver: number,
+  let portReceiver: number,
+      receiverPort: number,
       stopProcess: (() => Promise<void>) | undefined;
 
   setup(async (): Promise<void> => {
-    [ portPublisher, portReceiver ] = await getAvailablePorts({ count: 2 });
+    [ receiverPort, portReceiver ] = await getAvailablePorts({ count: 2 });
 
     stopProcess = await startProcess({
       runtime: 'microservice',
       name: 'domainEvent',
-      port: portPublisher,
+      port: receiverPort,
       env: {
         APPLICATION_DIRECTORY: applicationDirectory,
-        PORT_PUBLISHER: String(portPublisher),
+        PORT_PUBLISHER: String(receiverPort),
         PORT_RECEIVER: String(portReceiver),
         IDENTITY_PROVIDERS: `[{"issuer": "https://token.invalid", "certificate": "${certificateDirectory}"}]`
       }
@@ -50,7 +50,7 @@ suite('domain event', function (): void {
       test('is using the health API.', async (): Promise<void> => {
         const { status } = await axios({
           method: 'get',
-          url: `http://localhost:${portPublisher}/health/v2`
+          url: `http://localhost:${receiverPort}/health/v2`
         });
 
         assert.that(status).is.equalTo(200);
@@ -123,7 +123,7 @@ suite('domain event', function (): void {
         try {
           const { data } = await axios({
             method: 'get',
-            url: `http://localhost:${portPublisher}/domain-events/v2`,
+            url: `http://localhost:${receiverPort}/domain-events/v2`,
             responseType: 'stream'
           });
 

--- a/test/runtime/microservice/processes/domainEvent/processTests.ts
+++ b/test/runtime/microservice/processes/domainEvent/processTests.ts
@@ -3,7 +3,7 @@ import { assert } from 'assertthat';
 import { buildDomainEvent } from '../../../../shared/buildDomainEvent';
 import { DomainEvent } from '../../../../../lib/common/elements/DomainEvent';
 import { DomainEventWithState } from '../../../../../lib/common/elements/DomainEventWithState';
-import { getAvailablePort } from '../../../../../lib/common/utils/network/getAvailablePort';
+import { getAvailablePorts } from '../../../../../lib/common/utils/network/getAvailablePorts';
 import { getTestApplicationDirectory } from '../../../../shared/applications/getTestApplicationDirectory';
 import path from 'path';
 import { startProcess } from '../../../../shared/runtime/startProcess';
@@ -22,8 +22,7 @@ suite('domain event', function (): void {
       stopProcess: (() => Promise<void>) | undefined;
 
   setup(async (): Promise<void> => {
-    portPublisher = await getAvailablePort();
-    portReceiver = await getAvailablePort();
+    [ portPublisher, portReceiver ] = await getAvailablePorts({ count: 2 });
 
     stopProcess = await startProcess({
       runtime: 'microservice',

--- a/test/unit/common/utils/network/getAvailablePortsTests.ts
+++ b/test/unit/common/utils/network/getAvailablePortsTests.ts
@@ -1,0 +1,72 @@
+import { assert } from 'assertthat';
+import { getAvailablePorts } from '../../../../../lib/common/utils/network/getAvailablePorts';
+import http from 'http';
+import { sleep } from '../../../../../lib/common/utils/sleep';
+
+suite('getAvailablePorts', (): void => {
+  test('returns a list of available ports.', async (): Promise<void> => {
+    const firstServer = http.createServer((_req, res): void => {
+      res.end();
+    });
+    const secondServer = http.createServer((_req, res): void => {
+      res.end();
+    });
+
+    const [ firstPort, secondPort ] = await getAvailablePorts({ count: 2 });
+
+    let isFirstPortInUse = false,
+        isSecondPortInUse = false;
+
+    firstServer.on('error', (): void => {
+      isFirstPortInUse = true;
+    });
+    secondServer.on('error', (): void => {
+      isSecondPortInUse = true;
+    });
+
+    await new Promise((resolve): void => {
+      firstServer.listen(firstPort, (): void => {
+        resolve();
+      });
+    });
+    await new Promise((resolve): void => {
+      secondServer.listen(secondPort, (): void => {
+        resolve();
+      });
+    });
+
+    await sleep({ ms: 50 });
+
+    assert.that(isFirstPortInUse).is.false();
+    assert.that(isSecondPortInUse).is.false();
+  });
+
+  test('returns a list of available port that are not in use.', async (): Promise<void> => {
+    const firstServer = http.createServer((_req, res): void => {
+      res.end();
+    });
+    const secondServer = http.createServer((_req, res): void => {
+      res.end();
+    });
+
+    const [ firstPort, secondPort ] = await getAvailablePorts({ count: 2 });
+
+    await new Promise((resolve): void => {
+      firstServer.listen(firstPort, (): void => {
+        resolve();
+      });
+    });
+    await new Promise((resolve): void => {
+      secondServer.listen(secondPort, (): void => {
+        resolve();
+      });
+    });
+
+    await sleep({ ms: 50 });
+
+    const otherAvailablePorts = await getAvailablePorts({ count: 2 });
+
+    assert.that(otherAvailablePorts.includes(firstPort)).is.false();
+    assert.that(otherAvailablePorts.includes(secondPort)).is.false();
+  });
+});


### PR DESCRIPTION
Hey @yeldiRium 👋 

Although I had introduced the timeout in getting an available port, the tests still crashed from time to time, so I took some time to dive into this.

Found out that we had a race condition in one of the runtime tests, where we asked for two ports in sequence, without using them. So sometimes, the second was just the same as the first, and hence the tests crashed.

I have now changed the tests, and introduced a `getAvailablePorts` function which returns a number of available ports, in addition to the `getAvailablePort` function which returns only a single one.

If you are fine with this, could you please squash / merge this?