### PR TITLE
Make pre and post fail on error.

### DIFF
--- a/test/integration/post.ts
+++ b/test/integration/post.ts
@@ -1,15 +1,25 @@
+#!/usr/bin/env node
+
+import { flaschenpost } from 'flaschenpost';
 import { mariaDb, minio, mongoDb, mySql, postgres, redis, sqlServer } from '../shared/containers';
 
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async function (): Promise<void> {
-  await Promise.all([
-    mariaDb.stop(),
-    minio.stop(),
-    mongoDb.stop(),
-    mySql.stop(),
-    postgres.stop(),
-    redis.stop(),
-    sqlServer.stop()
-  ]);
+  const logger = flaschenpost.getLogger();
+
+  try {
+    await Promise.all([
+      mariaDb.stop(),
+      minio.stop(),
+      mongoDb.stop(),
+      mySql.stop(),
+      postgres.stop(),
+      redis.stop(),
+      sqlServer.stop()
+    ]);
+  } catch (ex) {
+    logger.fatal('An unexpected error occured.', { ex });
+    process.exit(1);
+  }
 })();
 /* eslint-enable @typescript-eslint/no-floating-promises */

--- a/test/integration/pre.ts
+++ b/test/integration/pre.ts
@@ -1,18 +1,28 @@
+#!/usr/bin/env node
+
 import { buildImages } from '../../docker/buildImages';
+import { flaschenpost } from 'flaschenpost';
 import { mariaDb, minio, mongoDb, mySql, postgres, redis, sqlServer } from '../shared/containers';
 
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async function (): Promise<void> {
-  await buildImages();
+  const logger = flaschenpost.getLogger();
 
-  await Promise.all([
-    mariaDb.start(),
-    minio.start(),
-    mongoDb.start(),
-    mySql.start(),
-    postgres.start(),
-    redis.start(),
-    sqlServer.start()
-  ]);
+  try {
+    await buildImages();
+
+    await Promise.all([
+      mariaDb.start(),
+      minio.start(),
+      mongoDb.start(),
+      mySql.start(),
+      postgres.start(),
+      redis.start(),
+      sqlServer.start()
+    ]);
+  } catch (ex) {
+    logger.fatal('An unexpected error occured.', { ex });
+    process.exit(1);
+  }
 })();
 /* eslint-enable @typescript-eslint/no-floating-promises */


### PR DESCRIPTION
Hi @yeldiRium 😊 

If pre and / or post of the integration tests failed, it didn't exit with an exit code 1. This has been fixed.

If you are fine with this, can you please squash / merge this?