### PR TITLE
Remove @mattwagl from Dependabot configuration.

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,7 +8,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -25,7 +24,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -37,7 +35,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -49,7 +46,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -61,7 +57,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -73,7 +68,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -85,7 +79,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -97,7 +90,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -109,7 +101,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"
@@ -121,7 +112,6 @@ update_configs:
     - "thenativeweb/wolkenkit-dev"
     default_assignees:
     - "goloroden"
-    - "mattwagl"
     - "yeldiRium"
     default_labels:
     - "Dependencies"


### PR DESCRIPTION
Hey @yeldiRium 👋 

In #305 I removed @mattwagl from the code owners file, since he mentioned that right now he would prefer if you and me merged PRs for wolkenkit. In consequence it doesn't make sense that Dependabot PRs get assigned to him, since he is not allowed to merge them anyway.

So to avoid that he gets lots of mails he does not need to care about, I removed him from the Dependabot configuration for now.

Can you please review, squash and merge?