### PR TITLE
Rewrite priority queue store interface.

### DIFF
--- a/lib/stores/priorityQueueStore/ItemIdentifier.ts
+++ b/lib/stores/priorityQueueStore/ItemIdentifier.ts
@@ -1,0 +1,9 @@
+import { AggregateIdentifier } from '../../common/elements/AggregateIdentifier';
+import { ContextIdentifier } from '../../common/elements/ContextIdentifier';
+
+export interface ItemIdentifier {
+  contextIdentifier: ContextIdentifier;
+  aggregateIdentifier: AggregateIdentifier;
+  id: string;
+  name: string;
+}

--- a/lib/stores/priorityQueueStore/PriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/PriorityQueueStore.ts
@@ -2,19 +2,20 @@ import { CommandData } from '../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../common/elements/CommandWithMetadata';
 import { DomainEvent } from '../../common/elements/DomainEvent';
 import { DomainEventData } from '../../common/elements/DomainEventData';
+import { ItemIdentifier } from './ItemIdentifier';
 
 export interface PriorityQueueStore<TItem extends CommandWithMetadata<CommandData> | DomainEvent<DomainEventData>> {
   enqueue ({ item }: { item: TItem }): Promise<void>;
 
   lockNext (): Promise<{ item: TItem; token: string } | undefined>;
 
-  renewLock ({ item, token }: {
-    item: TItem;
+  renewLock ({ itemIdentifier, token }: {
+    itemIdentifier: ItemIdentifier;
     token: string;
   }): Promise<void>;
 
-  acknowledge ({ item, token }: {
-    item: TItem;
+  acknowledge ({ itemIdentifier, token }: {
+    itemIdentifier: ItemIdentifier;
     token: string;
   }): Promise<void>;
 

--- a/test/integration/stores/priorityQueueStore/getTestsFor.ts
+++ b/test/integration/stores/priorityQueueStore/getTestsFor.ts
@@ -8,7 +8,7 @@ import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/Pr
 import { sleep } from '../../../../lib/common/utils/sleep';
 import { uuid } from 'uuidv4';
 
-const itemIdentifierFromCommand = function (command: CommandWithMetadata<CommandData>): ItemIdentifier {
+const getItemIdentifierFromCommand = function (command: CommandWithMetadata<CommandData>): ItemIdentifier {
   return {
     contextIdentifier: command.contextIdentifier,
     aggregateIdentifier: command.aggregateIdentifier,
@@ -201,7 +201,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
     test('throws an error if the given item is not enqueued.', async (): Promise<void> => {
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.renewLock({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'non-existent'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -214,7 +214,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.renewLock({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'non-existent'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -228,7 +228,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.renewLock({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'wrong-token'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -244,7 +244,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.renewLock({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.secondCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.secondCommand),
           token
         });
       }).is.throwingAsync((ex): boolean =>
@@ -259,7 +259,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await sleep({ ms: expirationTime * 0.75 });
       await priorityQueueStore.renewLock({
-        itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+        itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
         token
       });
       await sleep({ ms: expirationTime * 0.75 });
@@ -274,7 +274,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
     test('throws an error if the given item is not enqueued.', async (): Promise<void> => {
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.acknowledge({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'non-existent'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -287,7 +287,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.acknowledge({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'non-existent'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -301,7 +301,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.acknowledge({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
           token: 'wrong-token'
         });
       }).is.throwingAsync((ex): boolean =>
@@ -317,7 +317,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       await assert.that(async (): Promise<void> => {
         await priorityQueueStore.acknowledge({
-          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.secondCommand),
+          itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.secondCommand),
           token
         });
       }).is.throwingAsync((ex): boolean =>
@@ -332,7 +332,7 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       const { token } = (await priorityQueueStore.lockNext())!;
 
       await priorityQueueStore.acknowledge({
-        itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+        itemIdentifier: getItemIdentifierFromCommand(commands.firstAggregate.firstCommand),
         token
       });
 

--- a/test/integration/stores/priorityQueueStore/getTestsFor.ts
+++ b/test/integration/stores/priorityQueueStore/getTestsFor.ts
@@ -3,9 +3,19 @@ import { buildCommandWithMetadata } from '../../../shared/buildCommandWithMetada
 import { CommandData } from '../../../../lib/common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../lib/common/elements/CommandWithMetadata';
 import { CustomError } from 'defekt';
+import { ItemIdentifier } from '../../../../lib/stores/priorityQueueStore/ItemIdentifier';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 import { sleep } from '../../../../lib/common/utils/sleep';
 import { uuid } from 'uuidv4';
+
+const itemIdentifierFromCommand = function (command: CommandWithMetadata<CommandData>): ItemIdentifier {
+  return {
+    contextIdentifier: command.contextIdentifier,
+    aggregateIdentifier: command.aggregateIdentifier,
+    id: command.id,
+    name: command.name
+  };
+};
 
 /* eslint-disable mocha/max-top-level-suites, mocha/no-top-level-hooks */
 const getTestsFor = function ({ createPriorityQueueStore }: {
@@ -190,7 +200,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
   suite('renewLock', (): void => {
     test('throws an error if the given item is not enqueued.', async (): Promise<void> => {
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.renewLock({ item: commands.firstAggregate.firstCommand, token: 'non-existent' });
+        await priorityQueueStore.renewLock({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'non-existent'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTFOUND' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}' not found.`);
@@ -200,7 +213,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       await priorityQueueStore.enqueue({ item: commands.firstAggregate.firstCommand });
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.renewLock({ item: commands.firstAggregate.firstCommand, token: 'non-existent' });
+        await priorityQueueStore.renewLock({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'non-existent'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTLOCKED' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}' not locked.`);
@@ -211,7 +227,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       await priorityQueueStore.lockNext();
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.renewLock({ item: commands.firstAggregate.firstCommand, token: 'wrong-token' });
+        await priorityQueueStore.renewLock({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'wrong-token'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'ETOKENMISMATCH' &&
         ex.message === `Token mismatch for item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}'.`);
@@ -224,7 +243,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       const { token } = (await priorityQueueStore.lockNext())!;
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.renewLock({ item: commands.firstAggregate.secondCommand, token });
+        await priorityQueueStore.renewLock({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.secondCommand),
+          token
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTFOUND' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.secondCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.secondCommand.id}' not found.`);
@@ -236,7 +258,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       const { token } = (await priorityQueueStore.lockNext())!;
 
       await sleep({ ms: expirationTime * 0.75 });
-      await priorityQueueStore.renewLock({ item: commands.firstAggregate.firstCommand, token });
+      await priorityQueueStore.renewLock({
+        itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+        token
+      });
       await sleep({ ms: expirationTime * 0.75 });
 
       const nextCommand = await priorityQueueStore.lockNext();
@@ -248,7 +273,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
   suite('acknowledge', (): void => {
     test('throws an error if the given item is not enqueued.', async (): Promise<void> => {
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.acknowledge({ item: commands.firstAggregate.firstCommand, token: 'non-existent' });
+        await priorityQueueStore.acknowledge({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'non-existent'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTFOUND' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}' not found.`);
@@ -258,7 +286,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       await priorityQueueStore.enqueue({ item: commands.firstAggregate.firstCommand });
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.acknowledge({ item: commands.firstAggregate.firstCommand, token: 'non-existent' });
+        await priorityQueueStore.acknowledge({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'non-existent'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTLOCKED' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}' not locked.`);
@@ -269,7 +300,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       await priorityQueueStore.lockNext();
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.acknowledge({ item: commands.firstAggregate.firstCommand, token: 'wrong-token' });
+        await priorityQueueStore.acknowledge({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+          token: 'wrong-token'
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'ETOKENMISMATCH' &&
         ex.message === `Token mismatch for item 'sampleContext.sampleAggregate.${commands.firstAggregate.firstCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.firstCommand.id}'.`);
@@ -282,7 +316,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
       const { token } = (await priorityQueueStore.lockNext())!;
 
       await assert.that(async (): Promise<void> => {
-        await priorityQueueStore.acknowledge({ item: commands.firstAggregate.secondCommand, token });
+        await priorityQueueStore.acknowledge({
+          itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.secondCommand),
+          token
+        });
       }).is.throwingAsync((ex): boolean =>
         (ex as CustomError).code === 'EITEMNOTFOUND' &&
         ex.message === `Item 'sampleContext.sampleAggregate.${commands.firstAggregate.secondCommand.aggregateIdentifier.id}.execute.${commands.firstAggregate.secondCommand.id}' not found.`);
@@ -294,7 +331,10 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
 
       const { token } = (await priorityQueueStore.lockNext())!;
 
-      await priorityQueueStore.acknowledge({ item: commands.firstAggregate.firstCommand, token });
+      await priorityQueueStore.acknowledge({
+        itemIdentifier: itemIdentifierFromCommand(commands.firstAggregate.firstCommand),
+        token
+      });
 
       const { item: nextCommand } = (await priorityQueueStore.lockNext())!;
 


### PR DESCRIPTION
Hi @goloroden,

as in #339 discussed, I've rewritten the interface of the `PriorityQueueStore` to accept only the identifiers of the relevant items.

To help with that I've added the `ItemIdentifier` interface and placed it in the `priorityQueueStore` folder, since it is not relevant to the rest of the project so far.

Please take a look and feel free to merge, if all is well.