### PR TITLE
Extract streamNdjson middleware and use it in observeDomainEvents api.

### DIFF
--- a/lib/apis/middlewares/streamNdjson.ts
+++ b/lib/apis/middlewares/streamNdjson.ts
@@ -6,11 +6,9 @@ const logger = flaschenpost.getLogger();
 
 const heartbeat = { name: 'heartbeat' };
 
-/**
- * The streamNdjson middleware initializes a long-lived connection with the
- * content type `application/x-ndjson` and sends a periodic heartbeat every
- * `heartbeatInterval` milliseconds.
- */
+// The streamNdjson middleware initializes a long-lived connection with the
+// content type `application/x-ndjson` and sends a periodic heartbeat every
+// `heartbeatInterval` milliseconds.
 const streamNdjsonMiddleware = function ({
   heartbeatInterval
 }: {

--- a/lib/apis/middlewares/streamNdjson.ts
+++ b/lib/apis/middlewares/streamNdjson.ts
@@ -1,6 +1,6 @@
 import { flaschenpost } from 'flaschenpost';
-import { writeLine } from '../base/writeLine';
 import { RequestHandler } from 'express';
+import { writeLine } from '../base/writeLine';
 
 const logger = flaschenpost.getLogger();
 

--- a/lib/apis/middlewares/streamNdjson.ts
+++ b/lib/apis/middlewares/streamNdjson.ts
@@ -1,0 +1,60 @@
+import { flaschenpost } from 'flaschenpost';
+import { writeLine } from '../base/writeLine';
+import { RequestHandler } from 'express';
+
+const logger = flaschenpost.getLogger();
+
+const heartbeat = { name: 'heartbeat' };
+
+/**
+ * The streamNdjson middleware initializes a long-lived connection with the
+ * content type `application/x-ndjson` and sends a periodic heartbeat every
+ * `heartbeatInterval` milliseconds.
+ */
+const streamNdjsonMiddleware = function ({
+  heartbeatInterval
+}: {
+  heartbeatInterval: number;
+}): RequestHandler {
+  return async function (req, res, next): Promise<void> {
+    try {
+      let heartbeatIntervalId: NodeJS.Timeout;
+
+      req.setTimeout(0, (): void => undefined);
+      res.setTimeout(0);
+
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' });
+
+      res.connection.once('close', (): void => {
+        clearInterval(heartbeatIntervalId);
+      });
+
+      // Send an initial heartbeat to initialize the connection. If we do not do
+      // this, sometimes the connection does not become open until the first data
+      // is sent.
+      writeLine({ res, data: heartbeat });
+
+      heartbeatIntervalId = setInterval((): void => {
+        writeLine({ res, data: heartbeat });
+      }, heartbeatInterval);
+
+      return next();
+    } catch (ex) {
+      // It can happen that the connection gets closed in the background, and
+      // hence the underlying socket does not have a remote address any more. We
+      // can't detect this using an if statement, because connection handling is
+      // done by Node.js in a background thread, and we may have a race
+      // condition here. So, we decided to actively catch this exception, and
+      // take it as an indicator that the connection has been closed meanwhile.
+      if (ex.message === 'Remote address is missing.') {
+        return;
+      }
+
+      logger.error('An unexpected error occured.', { ex });
+
+      throw ex;
+    }
+  };
+};
+
+export { streamNdjsonMiddleware };

--- a/lib/apis/observeDomainEvents/http/index.ts
+++ b/lib/apis/observeDomainEvents/http/index.ts
@@ -10,6 +10,7 @@ import { PublishDomainEvent } from '../PublishDomainEvent';
 import { Repository } from '../../../common/domain/Repository';
 import { SpecializedEventEmitter } from '../../../common/utils/events/SpecializedEventEmitter';
 import { State } from '../../../common/elements/State';
+import { streamNdjsonMiddleware } from '../../middlewares/streamNdjson';
 import { validateDomainEventWithState } from '../../../common/validators/validateDomainEventWithState';
 import * as v2 from './v2';
 
@@ -47,12 +48,16 @@ const getApi = async function ({
     applicationDefinition
   }));
 
-  api.get('/v2/', authenticationMiddleware, v2.getDomainEvents({
-    applicationDefinition,
-    heartbeatInterval,
-    domainEventEmitter,
-    repository
-  }));
+  api.get(
+    '/v2/',
+    authenticationMiddleware,
+    streamNdjsonMiddleware({ heartbeatInterval }),
+    v2.getDomainEvents({
+      applicationDefinition,
+      domainEventEmitter,
+      repository
+    })
+  );
 
   const publishDomainEvent: PublishDomainEvent = function ({ domainEvent }): void {
     validateDomainEventWithState({ domainEvent, applicationDefinition });

--- a/test/shared/http/asJsonStream.ts
+++ b/test/shared/http/asJsonStream.ts
@@ -7,8 +7,9 @@ const asJsonStream = function <TItem> (...handleJson: ((item: TItem) => void)[])
     write (chunk: object, _, callback: (error?: any) => void): void {
       const data = JSON.parse(chunk.toString());
 
-      if (counter > handleJson.length) {
-        return callback(new Error(`Received ${counter + 1} items (${JSON.stringify(data)}), but only expected ${handleJson.length}.`));
+      // Ignore any messages after all handlers have been applied.
+      if (counter >= handleJson.length) {
+        return;
       }
 
       handleJson[counter](data);

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -31,25 +31,6 @@ suite('streamNdjson middleware', (): void => {
     });
   });
 
-  test('returns application/x-ndjson.', async (): Promise<void> => {
-    await new Promise((resolve, reject): void => {
-      try {
-        /* eslint-disable @typescript-eslint/no-floating-promises */
-        supertest(api).
-          get('/').
-          expect('Content-Type', 'application/x-ndjson').
-          pipe(asJsonStream<any>(
-            (): void => {
-              resolve();
-            }
-          ));
-        /* eslint-ensable @typescript-eslint/no-floating-promises */
-      } catch (ex) {
-        reject(ex);
-      }
-    });
-  });
-
   test('sends a periodic heartbeat.', async (): Promise<void> => {
     await new Promise((resolve, reject): void => {
       try {

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -12,7 +12,7 @@ suite('streamNdjson middleware', (): void => {
     api.get('/', streamNdjsonMiddleware({ heartbeatInterval: 1000 }));
   });
 
-  test('returns 200.', async (): Promise<void> => {
+  test('returns the status code 200.', async (): Promise<void> => {
     await new Promise((resolve, reject): void => {
       try {
         /* eslint-disable @typescript-eslint/no-floating-promises */
@@ -31,13 +31,13 @@ suite('streamNdjson middleware', (): void => {
     });
   });
 
-  test('returns application/json.', async (): Promise<void> => {
+  test('returns application/x-ndjson.', async (): Promise<void> => {
     await new Promise((resolve, reject): void => {
       try {
         /* eslint-disable @typescript-eslint/no-floating-promises */
         supertest(api).
           get('/').
-          expect('Content-Type', 'application/json; charset=utf-8').
+          expect('Content-Type', 'application/x-ndjson').
           pipe(asJsonStream<any>(
             (): void => {
               resolve();

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -55,11 +55,9 @@ suite('streamNdjson middleware', (): void => {
       try {
         supertest(api).get('/').pipe(asJsonStream<any>(
           (streamElement): void => {
-            console.log('heartbeat 1');
             assert.that(streamElement).is.equalTo({ name: 'heartbeat' });
           },
           (streamElement): void => {
-            console.log('heartbeat 2');
             assert.that(streamElement).is.equalTo({ name: 'heartbeat' });
             resolve();
           }

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -1,0 +1,72 @@
+import { asJsonStream } from '../../../shared/http/asJsonStream';
+import { assert } from 'assertthat';
+import { streamNdjsonMiddleware } from '../../../../lib/apis/middlewares/streamNdjson';
+import supertest from 'supertest';
+import express, { Application } from 'express';
+
+suite('streamNdjson middleware', (): void => {
+  let api: Application;
+
+  setup(async (): Promise<void> => {
+    api = express();
+    api.get('/', streamNdjsonMiddleware({ heartbeatInterval: 1000 }));
+  });
+
+  test('returns 200.', async (): Promise<void> => {
+    await new Promise((resolve, reject): void => {
+      try {
+        /* eslint-disable @typescript-eslint/no-floating-promises */
+        supertest(api).
+          get('/').
+          expect(200).
+          pipe(asJsonStream<any>(
+            (): void => {
+              resolve();
+            }
+          ));
+        /* eslint-enable @typescript-eslint/no-floating-promises */
+      } catch (ex) {
+        reject(ex);
+      }
+    });
+  });
+
+  test('returns application/json.', async (): Promise<void> => {
+    await new Promise((resolve, reject): void => {
+      try {
+        /* eslint-disable @typescript-eslint/no-floating-promises */
+        supertest(api).
+          get('/').
+          expect('Content-Type', 'application/json; charset=utf-8').
+          pipe(asJsonStream<any>(
+            (): void => {
+              resolve();
+            }
+          ));
+        /* eslint-ensable @typescript-eslint/no-floating-promises */
+      } catch (ex) {
+        reject(ex);
+      }
+    });
+  });
+
+  test('sends a periodic heartbeat.', async (): Promise<void> => {
+    await new Promise((resolve, reject): void => {
+      try {
+        supertest(api).get('/').pipe(asJsonStream<any>(
+          (streamElement): void => {
+            console.log('heartbeat 1');
+            assert.that(streamElement).is.equalTo({ name: 'heartbeat' });
+          },
+          (streamElement): void => {
+            console.log('heartbeat 2');
+            assert.that(streamElement).is.equalTo({ name: 'heartbeat' });
+            resolve();
+          }
+        ));
+      } catch (ex) {
+        reject(ex);
+      }
+    });
+  });
+});

--- a/test/unit/apis/observeDomainEvents/httpTests.ts
+++ b/test/unit/apis/observeDomainEvents/httpTests.ts
@@ -52,7 +52,7 @@ suite('observeDomainEvents/http', (): void => {
         }));
       });
 
-      test('returns 200.', async (): Promise<void> => {
+      test('returns the status code 200.', async (): Promise<void> => {
         await supertest(api).
           get('/v2/description').
           expect((res: Response): void => {


### PR DESCRIPTION
Hi @goloroden,

as discussed in #339 I've extracted a middleware from the `observeDomainEvents` api that sets up a connection as using `application/x-ndjson` and sends a heartbeat.

I've added tests for the middleware and had to make slight changes to the helper `WriteStream` `asJsonStream` which luckily don't affect the other places in which the helper is used.

Feel free to merge the changes if everything is well.