### PR TITLE
Add helper to create a PriorityQueueStore instance.

### DIFF
--- a/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
@@ -1,0 +1,23 @@
+import { CommandData } from '../../common/elements/CommandData';
+import { CommandWithMetadata } from '../../common/elements/CommandWithMetadata';
+import { DomainEvent } from '../../common/elements/DomainEvent';
+import { DomainEventData } from '../../common/elements/DomainEventData';
+import { errors } from '../../common/errors';
+import { InMemoryPriorityQueueStore } from './InMemory';
+import { PriorityQueueStore } from './PriorityQueueStore';
+
+const createPriorityQueueStore = async function<TItem extends CommandWithMetadata<CommandData> | DomainEvent<DomainEventData>> ({ type, options }: {
+  type: string;
+  options: any;
+}): Promise<PriorityQueueStore<TItem>> {
+  switch (type) {
+    case 'InMemory': {
+      return InMemoryPriorityQueueStore.create(options);
+    }
+    default: {
+      throw new errors.DatabaseTypeInvalid();
+    }
+  }
+};
+
+export { createPriorityQueueStore };


### PR DESCRIPTION
Hi @goloroden,

as further preparation for #339 I've added a helper function to easier create a `PriorityQueueStore` instance, mirroring the approach used for the `DomainEventStore`.

Feel free to merge it, if you're fine with it.