### PR TITLE
Replace supertest by custom implementation.

### DIFF
--- a/test/shared/http/runAsServer.ts
+++ b/test/shared/http/runAsServer.ts
@@ -1,0 +1,30 @@
+import { Application } from 'express';
+import { getAvailablePort } from '../../../lib/common/utils/network/getAvailablePort';
+import http from 'http';
+import axios, { AxiosInstance } from 'axios';
+
+const runAsServer = async function ({ app }: {
+  app: Application;
+}): Promise<AxiosInstance> {
+  const server = http.createServer(app);
+
+  const port = await getAvailablePort();
+
+  await new Promise((resolve, reject): void => {
+    server.listen(port, (): void => {
+      resolve();
+    });
+
+    server.on('error', (err): void => {
+      reject(err);
+    });
+  });
+
+  const axiosInstance = axios.create({
+    baseURL: `http://localhost:${port}`
+  });
+
+  return axiosInstance;
+};
+
+export { runAsServer };


### PR DESCRIPTION
Hey @yeldiRium 👋 

As announced on Slack earlier this day, I've tried to create a replacement for `supertest`, based on `axios`. It was actually way easier than I thought, and to prove that things work I have changed the tests for the NDJSON middleware to the new component.

I have not yet replaced it everywhere, and hence I have not yet removed the dependency to `supertest`. I first wanted to get some feedback from your side.

What do you think on this approach?

(It actually solves the issues we had with the tests, since `axios` has a way better interface than `superagent` when dealing with streams.)