### PR TITLE
Implement `hasNext` method on `PriorityQueueStore`.

### DIFF
--- a/lib/stores/priorityQueueStore/InMemory/InMemoryPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/InMemory/InMemoryPriorityQueueStore.ts
@@ -218,6 +218,24 @@ class InMemoryPriorityQueueStore<TItem extends CommandWithMetadata<CommandData> 
     );
   }
 
+  public async hasNext (): Promise<boolean> {
+    return await this.functionCallQueue.add(
+      async (): Promise<boolean> => {
+        if (this.queues.length === 0) {
+          return false;
+        }
+
+        const queue = this.queues[0]!;
+
+        if (queue.lock && queue.lock.until > Date.now()) {
+          return false;
+        }
+
+        return true;
+      }
+    );
+  }
+
   protected lockNextInternal (): { item: TItem; token: string } | undefined {
     if (this.queues.length === 0) {
       return;

--- a/lib/stores/priorityQueueStore/PriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/PriorityQueueStore.ts
@@ -7,6 +7,8 @@ import { ItemIdentifier } from '../../common/elements/ItemIdentifier';
 export interface PriorityQueueStore<TItem extends CommandWithMetadata<CommandData> | DomainEvent<DomainEventData>> {
   enqueue ({ item }: { item: TItem }): Promise<void>;
 
+  hasNext (): Promise<boolean>;
+
   lockNext (): Promise<{ item: TItem; token: string } | undefined>;
 
   renewLock ({ itemIdentifier, token }: {

--- a/test/integration/stores/priorityQueueStore/getTestsFor.ts
+++ b/test/integration/stores/priorityQueueStore/getTestsFor.ts
@@ -101,6 +101,33 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
     });
   });
 
+  suite('hasNext', (): void => {
+    test('returns false if there are no enqueued items.', async (): Promise<void> => {
+      assert.that(await priorityQueueStore.hasNext()).is.false();
+    });
+
+    test('returns true if there is an enqueued and unlocked item in the queue.', async (): Promise<void> => {
+      await priorityQueueStore.enqueue({ item: commands.firstAggregate.firstCommand });
+
+      assert.that(await priorityQueueStore.hasNext()).is.true();
+    });
+
+    test('does not lock the next item.', async (): Promise<void> => {
+      await priorityQueueStore.enqueue({ item: commands.firstAggregate.firstCommand });
+
+      assert.that(await priorityQueueStore.hasNext()).is.true();
+      assert.that(await priorityQueueStore.hasNext()).is.true();
+    });
+
+    test('returns false if all items in the queue are locked.', async (): Promise<void> => {
+      await priorityQueueStore.enqueue({ item: commands.firstAggregate.firstCommand });
+
+      await priorityQueueStore.lockNext();
+
+      assert.that(await priorityQueueStore.hasNext()).is.false();
+    });
+  });
+
   suite('lockNext', (): void => {
     test('returns undefined if there are no enqueued items.', async (): Promise<void> => {
       const nextCommand = await priorityQueueStore.lockNext();


### PR DESCRIPTION
This is a draft based on #355.

To centralize the polling from the priority queue I have implemented a `hasNext` method on said queue and I currently plan to call this method on a loop from the `awaitCommandWithMetadata` api. The incoming requests will (as was previously the case in the `getDomainEvent` api) be stored in a different internal queue (just an array) and every time a new item is available on the priority queue it will be locked and sent to the next open connection.

I'm done for today but will continue this on monday.