### PR TITLE
Implement dispatcher process for microservice runtime.

### DIFF
--- a/lib/runtimes/microservice/processes/dispatcher/Configuration.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/Configuration.ts
@@ -1,11 +1,10 @@
 export interface Configuration {
   applicationDirectory: string;
   priorityQueueStoreType: string;
-  priorityQueueStoreOptions: object;
+  priorityQueueStoreOptions: object & { expirationTime: number };
   awaitCommandCorsOrigin: string | string[];
   handleCommandCorsOrigin: string | string[];
   healthCorsOrigin: string | string[];
   port: number;
-  queueLockExpirationTime: number;
   queuePollInterval: number;
 }

--- a/lib/runtimes/microservice/processes/dispatcher/Configuration.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/Configuration.ts
@@ -1,0 +1,11 @@
+export interface Configuration {
+  applicationDirectory: string;
+  priorityQueueStoreType: string;
+  priorityQueueStoreOptions: object;
+  awaitCommandCorsOrigin: string | string[];
+  handleCommandCorsOrigin: string | string[];
+  healthCorsOrigin: string | string[];
+  port: number;
+  queueLockExpirationTime: number;
+  queuePollInterval: number;
+}

--- a/lib/runtimes/microservice/processes/dispatcher/app.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/app.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { CommandData } from '../../../../common/elements/CommandData';
+import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { createPriorityQueueStore } from '../../../../stores/priorityQueueStore/createPriorityQueueStore';
+import { flaschenpost } from 'flaschenpost';
+import { getApi } from './getApi';
+import { getApplicationDefinition } from '../../../../common/application/getApplicationDefinition';
+import { getConfiguration } from './getConfiguration';
+import { getOnReceiveCommand } from './getOnReceiveCommand';
+import http from 'http';
+import { registerExceptionHandler } from '../../../../common/utils/process/registerExceptionHandler';
+
+/* eslint-disable @typescript-eslint/no-floating-promises */
+(async (): Promise<void> => {
+  const logger = flaschenpost.getLogger();
+
+  try {
+    registerExceptionHandler();
+
+    const configuration = getConfiguration();
+
+    const applicationDefinition = await getApplicationDefinition({
+      applicationDirectory: configuration.applicationDirectory
+    });
+
+    const priorityQueueStore = await createPriorityQueueStore<CommandWithMetadata<CommandData>>({
+      type: configuration.priorityQueueStoreType,
+      options: {
+        ...configuration.priorityQueueStoreOptions,
+        expirationTime: configuration.queueLockExpirationTime
+      }
+    });
+
+    const onReceiveCommand = getOnReceiveCommand({
+      priorityQueueStore
+    });
+
+    const { api } = await getApi({
+      configuration,
+      applicationDefinition,
+      priorityQueueStore,
+      onReceiveCommand,
+      queuePollInterval: configuration.queuePollInterval
+    });
+
+    const server = http.createServer(api);
+
+    server.listen(configuration.port, (): void => {
+      logger.info('Dispatcher server started.', { port: configuration.port });
+    });
+  } catch (ex) {
+    logger.fatal('An unexpected error occured.', { ex });
+    process.exit(1);
+  }
+})();
+/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/lib/runtimes/microservice/processes/dispatcher/app.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/app.ts
@@ -28,7 +28,7 @@ import { registerExceptionHandler } from '../../../../common/utils/process/regis
       type: configuration.priorityQueueStoreType,
       options: {
         ...configuration.priorityQueueStoreOptions,
-        expirationTime: configuration.queueLockExpirationTime
+        expirationTime: configuration.priorityQueueStoreOptions.expirationTime
       }
     });
 

--- a/lib/runtimes/microservice/processes/dispatcher/getApi.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getApi.ts
@@ -43,8 +43,8 @@ const getApi = async function ({
   const api = express();
 
   api.use('/health', healthApi);
-  api.use('/handleCommand', handleCommandApi);
-  api.use('/awaitCommand', awaitCommandWithMetadataApi);
+  api.use('/handle-command', handleCommandApi);
+  api.use('/await-command', awaitCommandWithMetadataApi);
 
   return { api };
 };

--- a/lib/runtimes/microservice/processes/dispatcher/getApi.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getApi.ts
@@ -1,0 +1,52 @@
+import { ApplicationDefinition } from '../../../../common/application/ApplicationDefinition';
+import { CommandData } from '../../../../common/elements/CommandData';
+import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { Configuration } from './Configuration';
+import { getApi as getAwaitCommandWithMetadataApi } from '../../../../apis/awaitCommandWithMetadata/http';
+import { getCorsOrigin } from 'get-cors-origin';
+import { getApi as getHandleCommandWithMetadataApi } from '../../../../apis/handleCommandWithMetadata/http';
+import { getApi as getHealthApi } from '../../../../apis/getHealth/http';
+import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
+import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
+import express, { Application } from 'express';
+
+const getApi = async function ({
+  configuration,
+  applicationDefinition,
+  priorityQueueStore,
+  onReceiveCommand,
+  queuePollInterval
+}: {
+  configuration: Configuration;
+  applicationDefinition: ApplicationDefinition;
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  onReceiveCommand: OnReceiveCommand;
+  queuePollInterval: number;
+}): Promise<{ api: Application }> {
+  const { api: healthApi } = await getHealthApi({
+    corsOrigin: getCorsOrigin(configuration.healthCorsOrigin)
+  });
+
+  const { api: handleCommandApi } = await getHandleCommandWithMetadataApi({
+    corsOrigin: getCorsOrigin(configuration.handleCommandCorsOrigin),
+    onReceiveCommand,
+    applicationDefinition
+  });
+
+  const { api: awaitCommandWithMetadataApi } = await getAwaitCommandWithMetadataApi({
+    applicationDefinition,
+    corsOrigin: getCorsOrigin(configuration.awaitCommandCorsOrigin),
+    priorityQueueStore,
+    pollInterval: queuePollInterval
+  });
+
+  const api = express();
+
+  api.use('/health', healthApi);
+  api.use('/handleCommand', handleCommandApi);
+  api.use('/awaitCommand', awaitCommandWithMetadataApi);
+
+  return { api };
+};
+
+export { getApi };

--- a/lib/runtimes/microservice/processes/dispatcher/getConfiguration.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getConfiguration.ts
@@ -1,0 +1,56 @@
+import { Configuration } from './Configuration';
+import { getCorsSchema } from '../../../shared/schemas/getCorsSchema';
+import { getEnvironmentVariables } from '../../../../common/utils/process/getEnvironmentVariables';
+import { getPortSchema } from '../../../shared/schemas/getPortSchema';
+import path from 'path';
+import { withCamelCaseKeys } from '../../../../common/utils/withCamelCaseKeys';
+
+const corsSchema = getCorsSchema();
+const portSchema = getPortSchema();
+
+const getConfiguration = function (): Configuration {
+  const environmentVariables = getEnvironmentVariables({
+    APPLICATION_DIRECTORY: {
+      default: path.join(__dirname, '..', '..', '..', '..', '..', 'test', 'shared', 'applications', 'javascript', 'base'),
+      schema: { type: 'string', minLength: 1 }
+    },
+    PRIORITY_QUEUE_STORE_TYPE: {
+      default: 'InMemory',
+      schema: { type: 'string', minLength: 1 }
+    },
+    PRIORITY_QUEUE_STORE_OPTIONS: {
+      default: {},
+      schema: { type: 'object' }
+    },
+    AWAIT_COMMAND_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    HANDLE_COMMAND_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    HEALTH_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    PORT: {
+      default: 3_000,
+      schema: portSchema
+    },
+    QUEUE_LOCK_EXPIRATION_TIME: {
+      default: 5_000,
+      schema: { type: 'number', minimum: 1 }
+    },
+    QUEUE_POLL_INTERVAL: {
+      default: 500,
+      schema: { type: 'number', minimum: 1 }
+    }
+  });
+
+  return withCamelCaseKeys(environmentVariables) as Configuration;
+};
+
+export {
+  getConfiguration
+};

--- a/lib/runtimes/microservice/processes/dispatcher/getConfiguration.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getConfiguration.ts
@@ -20,7 +20,14 @@ const getConfiguration = function (): Configuration {
     },
     PRIORITY_QUEUE_STORE_OPTIONS: {
       default: {},
-      schema: { type: 'object' }
+      schema: {
+        type: 'object',
+        properties: {
+          expirationTime: { type: 'number', minimum: 1 }
+        },
+        required: [ 'expirationTime' ],
+        additionalProperties: true
+      }
     },
     AWAIT_COMMAND_CORS_ORIGIN: {
       default: '*',
@@ -37,10 +44,6 @@ const getConfiguration = function (): Configuration {
     PORT: {
       default: 3_000,
       schema: portSchema
-    },
-    QUEUE_LOCK_EXPIRATION_TIME: {
-      default: 5_000,
-      schema: { type: 'number', minimum: 1 }
     },
     QUEUE_POLL_INTERVAL: {
       default: 500,

--- a/lib/runtimes/microservice/processes/dispatcher/getOnReceiveCommand.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getOnReceiveCommand.ts
@@ -1,0 +1,19 @@
+import { CommandData } from '../../../../common/elements/CommandData';
+import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { flaschenpost } from 'flaschenpost';
+import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
+import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
+
+const logger = flaschenpost.getLogger();
+
+const getOnReceiveCommand = function ({ priorityQueueStore }: {
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+}): OnReceiveCommand {
+  return async function ({ command }): Promise<void> {
+    logger.debug('Received command, enqueueing it.', { command });
+
+    await priorityQueueStore.enqueue({ item: command });
+  };
+};
+
+export { getOnReceiveCommand };

--- a/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
@@ -12,7 +12,7 @@ const createPriorityQueueStore = async function<TItem extends CommandWithMetadat
 }): Promise<PriorityQueueStore<TItem>> {
   switch (type) {
     case 'InMemory': {
-      return InMemoryPriorityQueueStore.create(options);
+      return await InMemoryPriorityQueueStore.create(options);
     }
     default: {
       throw new errors.DatabaseTypeInvalid();

--- a/package-lock.json
+++ b/package-lock.json
@@ -764,27 +764,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.0"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.0",
-            "string.prototype.trimright": "^2.1.0"
-          }
-        }
       }
     },
     "array-union": {
@@ -989,74 +968,6 @@
         "chalk": "3.0.0",
         "inquirer": "7.0.1",
         "node-spinner": "0.0.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "inquirer": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
-          "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
-          "requires": {
-            "ansi-escapes": "^4.2.1",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^3.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^3.0.0",
-            "lodash": "^4.17.15",
-            "mute-stream": "0.0.8",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.5.3",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "bytes": {
@@ -1584,9 +1495,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "version": "1.17.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -1596,6 +1507,7 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
       }
@@ -2013,9 +1925,9 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2429,9 +2341,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+      "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
@@ -2442,7 +2354,7 @@
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
+        "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
@@ -2573,11 +2485,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
     },
     "is-regexp": {
@@ -3421,7 +3333,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -3439,27 +3350,6 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.0",
-            "string.prototype.trimright": "^2.1.0"
-          }
-        }
       }
     },
     "object.fromentries": {
@@ -3472,36 +3362,15 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.0",
-            "string.prototype.trimright": "^2.1.0"
-          }
-        }
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.values": {
@@ -3514,27 +3383,6 @@
         "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
-          "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.1.4",
-            "is-regex": "^1.0.4",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimleft": "^2.1.0",
-            "string.prototype.trimright": "^2.1.0"
-          }
-        }
       }
     },
     "on-finished": {
@@ -4228,6 +4076,21 @@
         "typescript": "3.7.3"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "buntstift": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/buntstift/-/buntstift-3.0.0.tgz",
@@ -4237,6 +4100,70 @@
             "chalk": "3.0.0",
             "inquirer": "7.0.0",
             "node-spinner": "0.0.4"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+          "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
           }
         },
         "semver": {
@@ -4252,6 +4179,23 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }

--- a/test/runtime/microservice/processes/dispatcher/processTests.ts
+++ b/test/runtime/microservice/processes/dispatcher/processTests.ts
@@ -1,0 +1,106 @@
+import { asJsonStream } from '../../../../shared/http/asJsonStream';
+import { assert } from 'assertthat';
+import axios from 'axios';
+import { buildCommandWithMetadata } from 'test/shared/buildCommandWithMetadata';
+import { getAvailablePorts } from '../../../../../lib/common/utils/network/getAvailablePorts';
+import { getTestApplicationDirectory } from '../../../../shared/applications/getTestApplicationDirectory';
+import path from 'path';
+import { startProcess } from '../../../../shared/runtime/startProcess';
+import { uuid } from 'uuidv4';
+
+const certificateDirectory = path.join(__dirname, '..', '..', '..', '..', '..', 'keys', 'local.wolkenkit.io');
+
+suite('dispatcher', function (): void {
+  this.timeout(10 * 1000);
+
+  const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
+
+  const queueLockExpirationTime = 600;
+  const queuePollInterval = 600;
+
+  let port: number,
+      stopProcess: (() => Promise<void>) | undefined;
+
+  setup(async (): Promise<void> => {
+    [ port ] = await getAvailablePorts({ count: 1 });
+
+    stopProcess = await startProcess({
+      runtime: 'microservice',
+      name: 'dispatcher',
+      port,
+      env: {
+        APPLICATION_DIRECTORY: applicationDirectory,
+        PORT: String(port),
+        IDENTITY_PROVIDERS: `[{"issuer": "https://token.invalid", "certificate": "${certificateDirectory}"}]`,
+        QUEUE_LOCK_EXPIRATION_TIME: String(queueLockExpirationTime),
+        QUEUE_POLL_INTERVAL: String(queuePollInterval)
+      }
+    });
+  });
+
+  teardown(async (): Promise<void> => {
+    if (stopProcess) {
+      await stopProcess();
+    }
+
+    stopProcess = undefined;
+  });
+
+  suite('GET /health/v2', (): void => {
+    test('is using the health API.', async (): Promise<void> => {
+      const { status } = await axios({
+        method: 'get',
+        url: `http://localhost:${port}/health/v2`
+      });
+
+      assert.that(status).is.equalTo(200);
+    });
+  });
+
+  suite('GET /awaitCommand/v2', (): void => {
+    test('delivers a command that is sent to /handleCommand/v2.', async (): Promise<void> => {
+      const command = buildCommandWithMetadata({
+        contextIdentifier: {
+          name: 'sampleContext'
+        },
+        aggregateIdentifier: {
+          name: 'sampleAggregate',
+          id: uuid()
+        },
+        name: 'execute',
+        data: {
+          strategy: 'succeed'
+        }
+      });
+
+      await axios({
+        method: 'post',
+        url: `http://localhost:${port}/handleCommand/v2`,
+        data: command
+      });
+
+      const { data } = await axios({
+        method: 'get',
+        url: `http://localhost:${port}/awaitCommand/v2`,
+        responseType: 'stream'
+      });
+
+      await new Promise((resolve, reject): void => {
+        data.on('error', (err: any): void => {
+          reject(err);
+        });
+
+        data.pipe(asJsonStream(
+          (streamElement): void => {
+            assert.that(streamElement).is.equalTo({ name: 'heartbeat' });
+          },
+          (streamElement: any): void => {
+            assert.that(streamElement.item).is.equalTo(command);
+
+            resolve();
+          }
+        ));
+      });
+    });
+  });
+});

--- a/test/runtime/microservice/processes/dispatcher/processTests.ts
+++ b/test/runtime/microservice/processes/dispatcher/processTests.ts
@@ -10,7 +10,7 @@ import { uuid } from 'uuidv4';
 
 const certificateDirectory = path.join(__dirname, '..', '..', '..', '..', '..', 'keys', 'local.wolkenkit.io');
 
-suite('dispatcher', function (): void {
+suite.only('dispatcher', function (): void {
   this.timeout(10 * 1000);
 
   const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
@@ -30,9 +30,9 @@ suite('dispatcher', function (): void {
       port,
       env: {
         APPLICATION_DIRECTORY: applicationDirectory,
+        PRIORITY_QUEUE_STORE_OPTIONS: `{"expirationTime":${queueLockExpirationTime}}`,
         PORT: String(port),
         IDENTITY_PROVIDERS: `[{"issuer": "https://token.invalid", "certificate": "${certificateDirectory}"}]`,
-        QUEUE_LOCK_EXPIRATION_TIME: String(queueLockExpirationTime),
         QUEUE_POLL_INTERVAL: String(queuePollInterval)
       }
     });

--- a/test/runtime/microservice/processes/dispatcher/processTests.ts
+++ b/test/runtime/microservice/processes/dispatcher/processTests.ts
@@ -10,7 +10,7 @@ import { uuid } from 'uuidv4';
 
 const certificateDirectory = path.join(__dirname, '..', '..', '..', '..', '..', 'keys', 'local.wolkenkit.io');
 
-suite.only('dispatcher', function (): void {
+suite('dispatcher', function (): void {
   this.timeout(10 * 1000);
 
   const applicationDirectory = getTestApplicationDirectory({ name: 'base' });

--- a/test/runtime/microservice/processes/dispatcher/processTests.ts
+++ b/test/runtime/microservice/processes/dispatcher/processTests.ts
@@ -57,8 +57,8 @@ suite('dispatcher', function (): void {
     });
   });
 
-  suite('GET /awaitCommand/v2', (): void => {
-    test('delivers a command that is sent to /handleCommand/v2.', async (): Promise<void> => {
+  suite('GET /await-command/v2', (): void => {
+    test('delivers a command that is sent to /handle-command/v2.', async (): Promise<void> => {
       const command = buildCommandWithMetadata({
         contextIdentifier: {
           name: 'sampleContext'
@@ -75,13 +75,13 @@ suite('dispatcher', function (): void {
 
       await axios({
         method: 'post',
-        url: `http://localhost:${port}/handleCommand/v2`,
+        url: `http://localhost:${port}/handle-command/v2`,
         data: command
       });
 
       const { data } = await axios({
         method: 'get',
-        url: `http://localhost:${port}/awaitCommand/v2`,
+        url: `http://localhost:${port}/await-command/v2`,
         responseType: 'stream'
       });
 


### PR DESCRIPTION
This is a draft based on #355.

It contains an implementation of the `dispatcher` process for the `microservices` runtime. If #355 in its current form at time of writing this PR will be merged, this can be merged directly after it (although due to the squash&merge approach a rebase will probably be necessary).

This implementation is built with the current polling concept in #355 in mind. If #358 were to be continued and merged before this PR, it would need a rewrite. But I suggest we merge this after #355 is done and then base #358 on this PR's content.