### PR TITLE
Fix command handler authorization.

### DIFF
--- a/lib/common/domain/handleCommand.ts
+++ b/lib/common/domain/handleCommand.ts
@@ -56,7 +56,7 @@ const handleCommand = async function ({
   try {
     const clonedCommand = cloneDeep(command);
 
-    const isAuthorized = await commandHandler.isAuthorized(currentAggregateState, clonedCommand, services);
+    const isAuthorized = await commandHandler.isAuthorized(currentAggregateState.state, clonedCommand, services);
 
     if (!isAuthorized) {
       throw new errors.CommandNotAuthorized();

--- a/test/shared/applications/javascript/base/build/domain/sampleContext/sampleAggregate/commands/authorize.js
+++ b/test/shared/applications/javascript/base/build/domain/sampleContext/sampleAggregate/commands/authorize.js
@@ -13,11 +13,18 @@ const authorize = {
   },
 
   isAuthorized (state, command) {
-    return command.shouldAuthorize;
+    // Reject authorization if we cannot see the state properties.
+    // That allows to verify that `handleCommand` passes the state value
+    // instead of the `CurrentAggregateState` wrapper object.
+    if (!Object.prototype.hasOwnProperty.call(state, 'domainEventNames')) {
+      return false;
+    }
+
+    return command.data.shouldAuthorize;
   },
 
   handle (state, command, { aggregate }) {
-    aggregate.publishDomainEvent('authorized');
+    aggregate.publishDomainEvent('authorized', {});
   }
 };
 

--- a/test/shared/applications/javascript/base/build/domain/sampleContext/sampleAggregate/commands/authorize.js
+++ b/test/shared/applications/javascript/base/build/domain/sampleContext/sampleAggregate/commands/authorize.js
@@ -13,10 +13,10 @@ const authorize = {
   },
 
   isAuthorized (state, command) {
-    // Reject authorization if we cannot see the state properties.
-    // That allows to verify that `handleCommand` passes the state value
-    // instead of the `CurrentAggregateState` wrapper object.
-    if (!Object.prototype.hasOwnProperty.call(state, 'domainEventNames')) {
+    // Reject authorization if we cannot see the state properties. That allows
+    // to verify that `handleCommand` passes the state value instead of the
+    // `CurrentAggregateState` wrapper object.
+    if (!state.domainEventNames) {
       return false;
     }
 

--- a/test/unit/common/domain/handleCommandTests.ts
+++ b/test/unit/common/domain/handleCommandTests.ts
@@ -129,7 +129,7 @@ suite('handleCommand', (): void => {
       ).is.undefined();
     });
 
-    test(`passes the correct state to the authorize handler.`, async (): Promise<void> => {
+    test('passes the correct state to the isAuthorized handler.', async (): Promise<void> => {
       const aggregateIdentifier = {
         name: 'sampleAggregate',
         id: uuid()

--- a/test/unit/common/domain/handleCommandTests.ts
+++ b/test/unit/common/domain/handleCommandTests.ts
@@ -128,6 +128,61 @@ suite('handleCommand', (): void => {
         await domainEventStore.getLastDomainEvent({ aggregateIdentifier })
       ).is.undefined();
     });
+
+    test(`passes the correct state to the authorize handler.`, async (): Promise<void> => {
+      const aggregateIdentifier = {
+        name: 'sampleAggregate',
+        id: uuid()
+      };
+
+      const command = buildCommandWithMetadata({
+        contextIdentifier: {
+          name: 'sampleContext'
+        },
+        aggregateIdentifier,
+        name: 'authorize',
+        data: {
+          shouldAuthorize: true
+        }
+      });
+
+      const collector = waitForSignals({ count: 1 });
+
+      // eslint-disable-next-line unicorn/consistent-function-scoping
+      const publishDomainEvents = async ({ domainEvents }: {
+        domainEvents: DomainEventWithState<DomainEventData, State>[];
+      }): Promise<void> => {
+        try {
+          assert.that(domainEvents.length).is.equalTo(1);
+          assert.that(domainEvents[0]).is.atLeast({
+            contextIdentifier: {
+              name: 'sampleContext'
+            },
+            aggregateIdentifier,
+            name: 'authorized',
+            data: {}
+          });
+
+          await collector.signal();
+        } catch (ex) {
+          await collector.fail(ex);
+        }
+      };
+
+      await handleCommand({
+        command,
+        applicationDefinition,
+        lockStore,
+        repository,
+        publishDomainEvents
+      });
+
+      await collector.promise;
+
+      assert.that(
+        await domainEventStore.getLastDomainEvent({ aggregateIdentifier })
+      ).is.not.undefined();
+    });
   });
 
   suite('handling', (): void => {


### PR DESCRIPTION
* Pass the state value instead of the CurrentAggregateState when calling `command#isAuthorized`.
* Alter the authorize test command to reject authorization when the state property is not found.
* Add test to verify that authorization passes with the correct state value.

This fixes a bug I encountered by adding custom authorization to an `amend` command on the sample `message` aggregate by using typescript.

The `CommandHandler` interface expects a `TState extends State` however `State` is a type redirecting to `object`.

This makes TS a bit confused with this defaulting to `object` and making the compiler accept to pass the `CurrentAggregateState<TState>` instead of the `TState` to the `isAuthorized` handler.