### PR TITLE
Include sourcemaps for Typescript users.

### DIFF
--- a/templates/blank/typescript/tsconfig.json
+++ b/templates/blank/typescript/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "sourceMap": true
+  },
   "include": [
     "./server/**/*.ts"
   ]

--- a/templates/chat-simplified/typescript/tsconfig.json
+++ b/templates/chat-simplified/typescript/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "sourceMap": true
+  },
   "include": [
     "./server/**/*.ts"
   ]

--- a/templates/chat/typescript/tsconfig.json
+++ b/templates/chat/typescript/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "sourceMap": true
+  },
   "include": [
     "./server/**/*.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "CommonJS",
     "outDir": "build",
     "resolveJsonModule": false,
+    "sourceMap": true,
     "strict": true,
     "target": "ES2019"
   },


### PR DESCRIPTION
Fixes #783.

It includes now `sourcemap` files along with typescript definitions.

This allows users to step through Wolkenkit sources during debug.

The published Wolkenkit package already embeds both typescript sources (`lib`) and compiled output (`build/lib`) so no additional work than publishing a new version should be required.