### PR TITLE
feat: Defer stream start in ndjson middleware until call from route.

### DIFF
--- a/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
@@ -15,9 +15,11 @@ const logger = flaschenpost.getLogger();
 const awaitCommandWithMetadata = {
   description: 'Sends the next available command.',
   path: '',
+
   request: {},
   response: {
-    statusCodes: [],
+    statusCodes: [ 200 ],
+
     stream: true,
     body: {
       type: 'object',
@@ -33,11 +35,13 @@ const awaitCommandWithMetadata = {
   getHandler ({
     priorityQueueStore,
     newCommandSubscriber,
-    newCommandSubscriberChannel
+    newCommandSubscriberChannel,
+    heartbeatInterval
   }: {
     priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
     newCommandSubscriber: Subscriber<object>;
     newCommandSubscriberChannel: string;
+    heartbeatInterval: number;
   }): WolkenkitRequestHandler {
     const responseBodySchema = new Value(awaitCommandWithMetadata.response.body);
 
@@ -63,6 +67,8 @@ const awaitCommandWithMetadata = {
     };
 
     return async function (req, res): Promise<void> {
+      req.startStream({ heartbeatInterval });
+
       const instantSuccess = await maybeHandleLock({ res });
 
       if (instantSuccess) {

--- a/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
@@ -67,7 +67,7 @@ const awaitCommandWithMetadata = {
     };
 
     return async function (req, res): Promise<void> {
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       const instantSuccess = await maybeHandleLock({ res });
 

--- a/lib/apis/awaitCommandWithMetadata/http/v2/index.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/index.ts
@@ -8,7 +8,6 @@ import { CorsOrigin } from 'get-cors-origin';
 import { getApiBase } from '../../../base/getApiBase';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import { renewLock } from './renewLock';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 import { Subscriber } from '../../../../messaging/pubSub/Subscriber';
 
 const getV2 = async function ({
@@ -39,11 +38,11 @@ const getV2 = async function ({
 
   api.get(
     `/${awaitCommandWithMetadata.path}`,
-    streamNdjsonMiddleware({ heartbeatInterval }),
     awaitCommandWithMetadata.getHandler({
       priorityQueueStore,
       newCommandSubscriber,
-      newCommandSubscriberChannel
+      newCommandSubscriberChannel,
+      heartbeatInterval
     })
   );
 

--- a/lib/apis/base/WolkenkitRequestHandler.ts
+++ b/lib/apis/base/WolkenkitRequestHandler.ts
@@ -1,3 +1,16 @@
-import { ParamsDictionary, RequestHandler } from 'express-serve-static-core';
+import { Params, ParamsDictionary, RequestHandler } from 'express-serve-static-core';
 
-export type WolkenkitRequestHandler = RequestHandler<ParamsDictionary, any, any, { [key: string]: any }>;
+export interface ParsedQs {
+  [key: string]: any;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    export interface Request {
+      startStream(parameters: { heartbeatInterval: number }): void;
+    }
+  }
+}
+
+export type WolkenkitRequestHandler<TParamsDictionay extends Params = ParamsDictionary, TResBody = any, TReqBody = any, TReqQuery = ParsedQs> = RequestHandler<TParamsDictionay, TResBody, TReqBody, TReqQuery>;

--- a/lib/apis/base/WolkenkitRequestHandler.ts
+++ b/lib/apis/base/WolkenkitRequestHandler.ts
@@ -7,7 +7,7 @@ export interface ParsedQs {
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace Express {
-    export interface Request {
+    export interface Response {
       startStream(parameters: { heartbeatInterval: number }): void;
     }
   }

--- a/lib/apis/base/getApiBase.ts
+++ b/lib/apis/base/getApiBase.ts
@@ -3,14 +3,11 @@ import cors from 'cors';
 import { GetApiBaseParameters } from './GetApiBaseParameters';
 import { jsonQueryParserMiddleware } from './jsonQueryParserMiddleware';
 import nocache from 'nocache';
+import { streamNdjsonMiddleware } from './streamNdjsonMiddleware';
 import express, { Application } from 'express';
 
 const getApiBase = async function ({ request, response }: GetApiBaseParameters): Promise<Application> {
   const api = express();
-
-  if (request.query.parser.useJson) {
-    api.use(jsonQueryParserMiddleware);
-  }
 
   if (request.headers.cors) {
     api.options('*', cors({
@@ -29,9 +26,15 @@ const getApiBase = async function ({ request, response }: GetApiBaseParameters):
     api.use(nocache());
   }
 
+  if (request.query.parser.useJson) {
+    api.use(jsonQueryParserMiddleware);
+  }
+
   if (request.body.parser) {
     api.use(bodyParser.json({ limit: request.body.parser.sizeLimit }));
   }
+
+  api.use(streamNdjsonMiddleware);
 
   return api;
 };

--- a/lib/apis/base/streamNdjsonMiddleware.ts
+++ b/lib/apis/base/streamNdjsonMiddleware.ts
@@ -15,7 +15,7 @@ const streamNdjsonMiddleware: WolkenkitRequestHandler = async function (
   next
 ): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/unbound-method,no-param-reassign
-  req.startStream = function ({ heartbeatInterval }): void {
+  res.startStream = function ({ heartbeatInterval }): void {
     try {
       let heartbeatIntervalId: NodeJS.Timeout;
 

--- a/lib/apis/base/streamNdjsonMiddleware.ts
+++ b/lib/apis/base/streamNdjsonMiddleware.ts
@@ -1,6 +1,6 @@
 import { flaschenpost } from 'flaschenpost';
-import { WolkenkitRequestHandler } from '../base/WolkenkitRequestHandler';
-import { writeLine } from '../base/writeLine';
+import { WolkenkitRequestHandler } from './WolkenkitRequestHandler';
+import { writeLine } from './writeLine';
 
 const logger = flaschenpost.getLogger();
 
@@ -9,12 +9,13 @@ const heartbeat = { name: 'heartbeat' };
 // The streamNdjson middleware initializes a long-lived connection with the
 // content type `application/x-ndjson` and sends a periodic heartbeat every
 // `heartbeatInterval` milliseconds.
-const streamNdjsonMiddleware = function ({
-  heartbeatInterval
-}: {
-  heartbeatInterval: number;
-}): WolkenkitRequestHandler {
-  return async function (req, res, next): Promise<void> {
+const streamNdjsonMiddleware: WolkenkitRequestHandler = async function (
+  req,
+  res,
+  next
+): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/unbound-method,no-param-reassign
+  req.startStream = function ({ heartbeatInterval }): void {
     try {
       let heartbeatIntervalId: NodeJS.Timeout;
 
@@ -53,6 +54,8 @@ const streamNdjsonMiddleware = function ({
       throw ex;
     }
   };
+
+  next();
 };
 
 export { streamNdjsonMiddleware };

--- a/lib/apis/observeDomainEvents/http/v2/getDomainEvents.ts
+++ b/lib/apis/observeDomainEvents/http/v2/getDomainEvents.ts
@@ -112,7 +112,7 @@ const getDomainEvents = {
       }
 
       try {
-        req.startStream({ heartbeatInterval });
+        res.startStream({ heartbeatInterval });
 
         res.connection.once('close', (): void => {
           domainEventEmitter.off(handleDomainEvent);

--- a/lib/apis/observeDomainEvents/http/v2/index.ts
+++ b/lib/apis/observeDomainEvents/http/v2/index.ts
@@ -12,7 +12,6 @@ import { PublishDomainEvent } from '../../PublishDomainEvent';
 import { Repository } from '../../../../common/domain/Repository';
 import { SpecializedEventEmitter } from '../../../../common/utils/events/SpecializedEventEmitter';
 import { State } from '../../../../common/elements/State';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 import { validateDomainEventWithState } from '../../../../common/validators/validateDomainEventWithState';
 
 const getV2 = async function ({
@@ -53,11 +52,11 @@ const getV2 = async function ({
   api.get(
     `/${getDomainEvents.path}`,
     authenticationMiddleware,
-    streamNdjsonMiddleware({ heartbeatInterval }),
     getDomainEvents.getHandler({
       applicationDefinition,
       domainEventEmitter,
-      repository
+      repository,
+      heartbeatInterval
     })
   );
 

--- a/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCausationId.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCausationId.ts
@@ -1,7 +1,6 @@
 import { DomainEventStore } from '../../../../stores/domainEventStore/DomainEventStore';
 import { getDomainEventSchema } from '../../../../common/schemas/getDomainEventSchema';
 import { jsonSchema } from 'uuidv4';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 import { Value } from 'validate-value';
 import { WolkenkitRequestHandler } from '../../../base/WolkenkitRequestHandler';
 import { writeLine } from '../../../base/writeLine';
@@ -34,16 +33,19 @@ const getDomainEventsByCausationId = {
     domainEventStore: DomainEventStore;
     heartbeatInterval: number;
   }): WolkenkitRequestHandler {
-    const responseBodySchema = new Value(getDomainEventsByCausationId.response.body);
+    const querySchema = new Value(getDomainEventsByCausationId.request.query),
+          responseBodySchema = new Value(getDomainEventsByCausationId.response.body);
 
     return async function (req, res): Promise<any> {
+      try {
+        querySchema.validate(req.query);
+      } catch (ex) {
+        res.status(400).end(ex.message);
+      }
+
       const causationId = req.query['causation-id'] as string;
 
-      const heartbeatMiddleware = streamNdjsonMiddleware({ heartbeatInterval });
-
-      await heartbeatMiddleware(req, res, (): void => {
-        // No need for a `next`-callback for this middleware.
-      });
+      req.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getDomainEventsByCausationId({ causationId });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCausationId.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCausationId.ts
@@ -45,7 +45,7 @@ const getDomainEventsByCausationId = {
 
       const causationId = req.query['causation-id'] as string;
 
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getDomainEventsByCausationId({ causationId });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCorrelationId.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCorrelationId.ts
@@ -1,7 +1,6 @@
 import { DomainEventStore } from '../../../../stores/domainEventStore/DomainEventStore';
 import { getDomainEventSchema } from '../../../../common/schemas/getDomainEventSchema';
 import { jsonSchema } from 'uuidv4';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 import { Value } from 'validate-value';
 import { WolkenkitRequestHandler } from '../../../base/WolkenkitRequestHandler';
 import { writeLine } from '../../../base/writeLine';
@@ -34,16 +33,19 @@ const getDomainEventsByCorrelationId = {
     domainEventStore: DomainEventStore;
     heartbeatInterval: number;
   }): WolkenkitRequestHandler {
-    const responseBodySchema = new Value(getDomainEventsByCorrelationId.response.body);
+    const querySchema = new Value(getDomainEventsByCorrelationId.request.query),
+          responseBodySchema = new Value(getDomainEventsByCorrelationId.response.body);
 
     return async function (req, res): Promise<any> {
+      try {
+        querySchema.validate(req.query);
+      } catch (ex) {
+        res.status(400).end(ex.message);
+      }
+
       const correlationId = req.query['correlation-id'] as string;
 
-      const heartbeatMiddleware = streamNdjsonMiddleware({ heartbeatInterval });
-
-      await heartbeatMiddleware(req, res, (): void => {
-        // No need for a `next`-callback for this middleware.
-      });
+      req.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getDomainEventsByCorrelationId({ correlationId });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCorrelationId.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getDomainEventsByCorrelationId.ts
@@ -45,7 +45,7 @@ const getDomainEventsByCorrelationId = {
 
       const correlationId = req.query['correlation-id'] as string;
 
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getDomainEventsByCorrelationId({ correlationId });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getReplay.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getReplay.ts
@@ -44,7 +44,7 @@ const getReplay = {
 
       const fromTimestamp = req.query.fromTimestamp as number;
 
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getReplay({ fromTimestamp });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getReplayForAggregate.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getReplayForAggregate.ts
@@ -57,7 +57,7 @@ const getReplayForAggregate = {
         return res.status(400).end('Aggregate id must be a uuid.');
       }
 
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getReplayForAggregate({ aggregateId, fromRevision, toRevision });
 

--- a/lib/apis/queryDomainEventStore/http/v2/getReplayForAggregate.ts
+++ b/lib/apis/queryDomainEventStore/http/v2/getReplayForAggregate.ts
@@ -1,7 +1,6 @@
 import { DomainEventStore } from '../../../../stores/domainEventStore/DomainEventStore';
 import { getDomainEventSchema } from '../../../../common/schemas/getDomainEventSchema';
 import { isUuid } from 'uuidv4';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 import { Value } from 'validate-value';
 import { WolkenkitRequestHandler } from '../../../base/WolkenkitRequestHandler';
 import { writeLine } from '../../../base/writeLine';
@@ -39,18 +38,17 @@ const getReplayForAggregate = {
           responseBodySchema = new Value(getReplayForAggregate.response.body);
 
     return async function (req, res): Promise<any> {
-      let fromRevision: number | undefined,
-          toRevision: number | undefined;
-
       try {
         querySchema.validate(req.query);
-        ({ fromRevision, toRevision } = req.query);
-
-        if (fromRevision && toRevision && fromRevision > toRevision) {
-          return res.status(400).send(`Query parameter 'toRevision' must be greater or equal to 'fromRevision'.`);
-        }
       } catch (ex) {
         return res.status(400).send(ex.message);
+      }
+
+      const fromRevision = req.query.fromRevision as number,
+            toRevision = req.query.toRevision as number;
+
+      if (fromRevision && toRevision && fromRevision > toRevision) {
+        return res.status(400).send(`Query parameter 'toRevision' must be greater or equal to 'fromRevision'.`);
       }
 
       const { aggregateId } = req.params;
@@ -59,11 +57,7 @@ const getReplayForAggregate = {
         return res.status(400).end('Aggregate id must be a uuid.');
       }
 
-      const heartbeatMiddleware = streamNdjsonMiddleware({ heartbeatInterval });
-
-      await heartbeatMiddleware(req, res, (): void => {
-        // No need for a `next`-callback for this middleware.
-      });
+      req.startStream({ heartbeatInterval });
 
       const domainEventStream = await domainEventStore.getReplayForAggregate({ aggregateId, fromRevision, toRevision });
 

--- a/lib/apis/subscribeMessages/http/v2/getMessages.ts
+++ b/lib/apis/subscribeMessages/http/v2/getMessages.ts
@@ -14,13 +14,18 @@ const getMessages = {
   request: {},
   response: {
     statusCodes: [ 200 ],
-    stream: true
+
+    stream: true,
+    body: {}
   },
 
-  getHandler ({ messageEmitter }: {
+  getHandler ({ messageEmitter, heartbeatInterval }: {
     messageEmitter: SpecializedEventEmitter<object>;
+    heartbeatInterval: number;
   }): WolkenkitRequestHandler {
-    return async function (_req: Request, res: Response): Promise<void> {
+    return async function (req: Request, res: Response): Promise<void> {
+      req.startStream({ heartbeatInterval });
+
       try {
         const messageQueue = new PQueue({ concurrency: 1 });
 

--- a/lib/apis/subscribeMessages/http/v2/getMessages.ts
+++ b/lib/apis/subscribeMessages/http/v2/getMessages.ts
@@ -24,7 +24,7 @@ const getMessages = {
     heartbeatInterval: number;
   }): WolkenkitRequestHandler {
     return async function (req: Request, res: Response): Promise<void> {
-      req.startStream({ heartbeatInterval });
+      res.startStream({ heartbeatInterval });
 
       try {
         const messageQueue = new PQueue({ concurrency: 1 });

--- a/lib/apis/subscribeMessages/http/v2/index.ts
+++ b/lib/apis/subscribeMessages/http/v2/index.ts
@@ -4,7 +4,6 @@ import { getApiBase } from '../../../base/getApiBase';
 import { getMessages } from './getMessages';
 import { PublishMessage } from '../../PublishMessage';
 import { SpecializedEventEmitter } from '../../../../common/utils/events/SpecializedEventEmitter';
-import { streamNdjsonMiddleware } from '../../../middlewares/streamNdjson';
 
 const getV2 = async function ({ corsOrigin, heartbeatInterval = 90_000 }: {
   corsOrigin: CorsOrigin;
@@ -25,8 +24,10 @@ const getV2 = async function ({ corsOrigin, heartbeatInterval = 90_000 }: {
 
   api.get(
     `/${getMessages.path}`,
-    streamNdjsonMiddleware({ heartbeatInterval }),
-    getMessages.getHandler({ messageEmitter })
+    getMessages.getHandler({
+      messageEmitter,
+      heartbeatInterval
+    })
   );
 
   const publishMessage: PublishMessage = function ({ message }): void {

--- a/test/unit/apis/base/streamNdjsonTests.ts
+++ b/test/unit/apis/base/streamNdjsonTests.ts
@@ -10,7 +10,7 @@ suite('streamNdjson middleware', (): void => {
   setup(async (): Promise<void> => {
     app = express();
     app.use(streamNdjsonMiddleware);
-    app.get('/', (req): void => {
+    app.get('/', (_req, res): void => {
       res.startStream({ heartbeatInterval: 1000 });
     });
   });

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -11,7 +11,7 @@ suite('streamNdjson middleware', (): void => {
     app = express();
     app.use(streamNdjsonMiddleware);
     app.get('/', (req): void => {
-      req.startStream({ heartbeatInterval: 1000 });
+      res.startStream({ heartbeatInterval: 1000 });
     });
   });
 

--- a/test/unit/apis/middlewares/streamNdjsonTests.ts
+++ b/test/unit/apis/middlewares/streamNdjsonTests.ts
@@ -1,7 +1,7 @@
 import { asJsonStream } from '../../../shared/http/asJsonStream';
 import { assert } from 'assertthat';
 import { runAsServer } from '../../../shared/http/runAsServer';
-import { streamNdjsonMiddleware } from '../../../../lib/apis/middlewares/streamNdjson';
+import { streamNdjsonMiddleware } from '../../../../lib/apis/base/streamNdjsonMiddleware';
 import express, { Application } from 'express';
 
 suite('streamNdjson middleware', (): void => {
@@ -9,7 +9,10 @@ suite('streamNdjson middleware', (): void => {
 
   setup(async (): Promise<void> => {
     app = express();
-    app.get('/', streamNdjsonMiddleware({ heartbeatInterval: 1000 }));
+    app.use(streamNdjsonMiddleware);
+    app.get('/', (req): void => {
+      req.startStream({ heartbeatInterval: 1000 });
+    });
   });
 
   test('returns the status code 200.', async (): Promise<void> => {

--- a/test/unit/apis/observeDomainEvents/httpTests.ts
+++ b/test/unit/apis/observeDomainEvents/httpTests.ts
@@ -112,6 +112,19 @@ suite('observeDomainEvents/http', (): void => {
         }));
       });
 
+      test('returns a 400 if the query is malformed.', async (): Promise<void> => {
+        const { client } = await runAsServer({ app: api });
+
+        const { status } = await client({
+          method: 'get',
+          url: '/v2/?foo=bar',
+          responseType: 'stream',
+          validateStatus: (): boolean => true
+        });
+
+        assert.that(status).is.equalTo(400);
+      });
+
       test('delivers a single domain event.', async (): Promise<void> => {
         const executed = new DomainEventWithState({
           ...buildDomainEvent({


### PR DESCRIPTION
This closes #836.

Extends the express Request type with the new method `startStream`,
which then sends headers and status 200 and starts the heartbeat.
The middleware is now included with the base api and usage is decided
in the individual routes.