### PR TITLE
feat: Split handleCommand api into separate routes for commands.

### DIFF
--- a/lib/apis/handleCommand/http/v2/Client.ts
+++ b/lib/apis/handleCommand/http/v2/Client.ts
@@ -35,8 +35,8 @@ class Client extends HttpClient {
   }): Promise<{ id: string }> {
     const { status, data } = await axios({
       method: 'post',
-      url: `${this.url}/`,
-      data: command,
+      url: `${this.url}/${command.contextIdentifier.name}/${command.aggregateIdentifier.name}/${command.aggregateIdentifier.id}/${command.name}`,
+      data: command.data,
       validateStatus (): boolean {
         return true;
       }

--- a/lib/apis/handleCommand/http/v2/postCommand.ts
+++ b/lib/apis/handleCommand/http/v2/postCommand.ts
@@ -37,8 +37,7 @@ const postCommand = {
     onReceiveCommand: OnReceiveCommand;
     applicationDefinition: ApplicationDefinition;
   }): WolkenkitRequestHandler {
-    const requestBodySchema = new Value(postCommand.request.body),
-          responseBodySchema = new Value(postCommand.response.body);
+    const responseBodySchema = new Value(postCommand.response.body);
 
     return async function (req, res): Promise<void> {
       if (!req.token || !req.user) {
@@ -68,7 +67,6 @@ const postCommand = {
 
         return;
       }
-
 
       const command = new Command({
         contextIdentifier: {

--- a/lib/apis/handleCommand/http/v2/postCommand.ts
+++ b/lib/apis/handleCommand/http/v2/postCommand.ts
@@ -4,6 +4,7 @@ import { Command } from '../../../../common/elements/Command';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
+import { getCommandSchema } from '../../../../common/schemas/getCommandSchema';
 import { OnReceiveCommand } from '../../OnReceiveCommand';
 import typer from 'content-type';
 import { validateCommand } from '../../../../common/validators/validateCommand';
@@ -68,18 +69,6 @@ const postCommand = {
         return;
       }
 
-      try {
-        requestBodySchema.validate(req.body);
-      } catch (ex) {
-        const error = new errors.RequestMalformed(ex.message);
-
-        res.status(400).json({
-          code: error.code,
-          message: error.message
-        });
-
-        return;
-      }
 
       const command = new Command({
         contextIdentifier: {
@@ -92,6 +81,19 @@ const postCommand = {
         name: req.params.commandName,
         data: req.body
       });
+
+      try {
+        new Value(getCommandSchema()).validate(command);
+      } catch (ex) {
+        const error = new errors.RequestMalformed(ex.message);
+
+        res.status(400).json({
+          code: error.code,
+          message: error.message
+        });
+
+        return;
+      }
 
       try {
         validateCommand({ command, applicationDefinition });

--- a/test/unit/apis/handleCommand/httpTests.ts
+++ b/test/unit/apis/handleCommand/httpTests.ts
@@ -144,6 +144,26 @@ suite('handleCommand/http', (): void => {
         });
       });
 
+      test('returns 400 if the aggregate id is not a uuid.', async (): Promise<void> => {
+        const { client } = await runAsServer({ app: api });
+
+        const { status, data } = await client({
+          method: 'post',
+          url: `/v2/nonExistent/sampleAggregate/not-a-uuid/execute`,
+          data: { strategy: 'succeed' },
+          responseType: 'text',
+          validateStatus (): boolean {
+            return true;
+          }
+        });
+
+        assert.that(status).is.equalTo(400);
+        assert.that(data).is.equalTo({
+          code: 'EREQUESTMALFORMED',
+          message: 'String does not match pattern: (?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/ (at value.aggregateIdentifier.id).'
+        });
+      });
+
       test('returns 400 if a non-existent context name is given.', async (): Promise<void> => {
         const { client } = await runAsServer({ app: api });
 


### PR DESCRIPTION
Closes #565.