### PR TITLE
Fix syntax errors in docker and docker compose manifests

### DIFF
--- a/lib/clis/wolkenkit/createDeployment/dockerCompose/getMicroserviceInMemoryManifest.ts
+++ b/lib/clis/wolkenkit/createDeployment/dockerCompose/getMicroserviceInMemoryManifest.ts
@@ -220,12 +220,12 @@ const getMicroserviceInMemoryManifest = function ({ appName }: {
           start_period: 30s
 
       graphql:
-        build: '../..
+        build: '../..'
         command: 'node ./node_modules/wolkenkit/build/lib/runtimes/microservice/processes/graphql/app.js'
         environment:
           NODE_ENV: 'production'
           APPLICATION_DIRECTORY: '/app'
-          ENABLE_INTEGRATED_CLIENT: false
+          ENABLE_INTEGRATED_CLIENT: 'false'
           CORS_ORIGIN: '*'
           DOMAIN_EVENT_STORE_OPTIONS: '${domainEventStoreOptions}'
           DOMAIN_EVENT_STORE_TYPE: '${domainEventStoreType}'

--- a/lib/clis/wolkenkit/createDeployment/dockerCompose/getMicroservicePostgresManifest.ts
+++ b/lib/clis/wolkenkit/createDeployment/dockerCompose/getMicroservicePostgresManifest.ts
@@ -255,12 +255,12 @@ const getMicroservicePostgresManifest = function ({ appName }: {
           start_period: 30s
 
       graphql:
-        build: '../..
+        build: '../..'
         command: 'node ./node_modules/wolkenkit/build/lib/runtimes/microservice/processes/graphql/app.js'
         environment:
           NODE_ENV: 'production'
           APPLICATION_DIRECTORY: '/app'
-          GRAPHQL_PLAYGROUND: false
+          GRAPHQL_PLAYGROUND: 'false'
           CORS_ORIGIN: '*'
           DOMAIN_EVENT_STORE_OPTIONS: '${domainEventStoreOptions}'
           DOMAIN_EVENT_STORE_TYPE: '${domainEventStoreType}'

--- a/lib/clis/wolkenkit/createDeployment/dockerCompose/getSingleProcessInMemoryManifest.ts
+++ b/lib/clis/wolkenkit/createDeployment/dockerCompose/getSingleProcessInMemoryManifest.ts
@@ -35,7 +35,7 @@ const getSingleProcessInMemoryManifest = function ({ appName }: {
         environment:
           NODE_ENV: 'production'
           APPLICATION_DIRECTORY: '/app'
-          HTTP_API: true
+          HTTP_API: 'true'
           GRAPHQL_API: '{"enableIntegratedClient":false}'
           COMMAND_QUEUE_RENEW_INTERVAL: ${5_000}
           CONCURRENT_COMMANDS: ${100}

--- a/lib/clis/wolkenkit/createDeployment/dockerCompose/getSingleProcessPostgresManifest.ts
+++ b/lib/clis/wolkenkit/createDeployment/dockerCompose/getSingleProcessPostgresManifest.ts
@@ -75,7 +75,7 @@ const getSingleProcessPostgresManifest = function ({ appName }: {
         environment:
           NODE_ENV: 'production'
           APPLICATION_DIRECTORY: '/app'
-          HTTP_API: true
+          HTTP_API: 'true'
           GRAPHQL_API: '{"enableIntegratedClient":false}'
           COMMAND_QUEUE_RENEW_INTERVAL: ${5_000}
           CONCURRENT_COMMANDS: ${100}

--- a/lib/clis/wolkenkit/init/createDockerConfiguration.ts
+++ b/lib/clis/wolkenkit/init/createDockerConfiguration.ts
@@ -31,7 +31,7 @@ const createDockerConfiguration = async function ({ directory }: {
         RUN mkdir /app
         WORKDIR /app
 
-        ADD ./package.json ./.npmrc* .
+        ADD ./package.json ./.npmrc* ./
         RUN npm install
 
         ADD . .
@@ -44,7 +44,7 @@ const createDockerConfiguration = async function ({ directory }: {
         RUN mkdir /app
         WORKDIR /app
 
-        ADD ./package.json ./.npmrc* .
+        ADD ./package.json ./.npmrc* ./
         RUN npm install --production
 
 


### PR DESCRIPTION
fix: syntax errors in docker and docker compose manifests.

They don't work OOTB with docker 19.03.8 and docker-compose 1.25.5.