### PR TITLE
Fix domain microservice dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15345,8 +15345,7 @@
     "streamtoarray": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/streamtoarray/-/streamtoarray-3.0.0.tgz",
-      "integrity": "sha512-CS0kYikGaCQ8VkGkWlYMhx3yDv70pyrpRcuQSnd8ETJA3ef9CGpZt7bt0cuyeewxMkdDonmwk/Nb2Jank/C+Qg==",
-      "dev": true
+      "integrity": "sha512-CS0kYikGaCQ8VkGkWlYMhx3yDv70pyrpRcuQSnd8ETJA3ef9CGpZt7bt0cuyeewxMkdDonmwk/Nb2Jank/C+Qg=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "saslprep": "1.0.3",
     "shelljs": "0.8.4",
     "stream-to-string": "1.2.0",
+    "streamtoarray": "3.0.0",
     "untildify": "4.0.0",
     "uuidv4": "6.1.0",
     "validate-value": "7.0.0"
@@ -178,7 +179,6 @@
     "react-dom": "16.13.1",
     "record-stdstreams": "3.0.0",
     "roboter": "11.2.0",
-    "streamtoarray": "3.0.0",
     "subscriptions-transport-ws": "0.9.16",
     "thenativeweb-ux": "5.6.4",
     "wait-for-signals": "1.1.0",


### PR DESCRIPTION
Move `streamtoarray` to dependencies.

The domain microservice needs it.