### PR TITLE
feat: Implement command cancelling.

### DIFF
--- a/lib/apis/awaitCommandWithMetadata/http/index.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/index.ts
@@ -3,6 +3,7 @@ import { CommandData } from '../../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../../common/elements/CommandWithMetadata';
 import { CorsOrigin } from 'get-cors-origin';
 import { getV2 } from './v2';
+import { ItemIdentifierWithClient } from '../../../common/elements/ItemIdentifierWithClient';
 import { PriorityQueueStore } from '../../../stores/priorityQueueStore/PriorityQueueStore';
 import { Subscriber } from '../../../messaging/pubSub/Subscriber';
 import express, { Application } from 'express';
@@ -17,7 +18,7 @@ const getApi = async function ({
 }: {
   applicationDefinition: ApplicationDefinition;
   corsOrigin: CorsOrigin;
-  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   newCommandSubscriber: Subscriber<object>;
   newCommandSubscriberChannel: string;
   heartbeatInterval?: number;

--- a/lib/apis/awaitCommandWithMetadata/http/v2/acknowledge.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/acknowledge.ts
@@ -4,6 +4,7 @@ import { CommandWithMetadata } from '../../../../common/elements/CommandWithMeta
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
 import { getItemIdentifierSchema } from '../../../../common/schemas/getItemIdentifierSchema';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { jsonSchema } from 'uuidv4';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import typer from 'content-type';
@@ -38,7 +39,7 @@ const acknowledge = {
     priorityQueueStore
   }: {
     applicationDefinition: ApplicationDefinition;
-    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   }): WolkenkitRequestHandler {
     const requestBodySchema = new Value(acknowledge.request.body),
           responseBodySchema = new Value(acknowledge.response.body);

--- a/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/awaitCommandWithMetadata.ts
@@ -2,6 +2,7 @@ import { CommandData } from '../../../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
 import { flaschenpost } from 'flaschenpost';
 import { getCommandWithMetadataSchema } from '../../../../common/schemas/getCommandWithMetadataSchema';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { jsonSchema } from 'uuidv4';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import { Response } from 'express';
@@ -38,7 +39,7 @@ const awaitCommandWithMetadata = {
     newCommandSubscriberChannel,
     heartbeatInterval
   }: {
-    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
     newCommandSubscriber: Subscriber<object>;
     newCommandSubscriberChannel: string;
     heartbeatInterval: number;

--- a/lib/apis/awaitCommandWithMetadata/http/v2/defer.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/defer.ts
@@ -4,6 +4,7 @@ import { CommandWithMetadata } from '../../../../common/elements/CommandWithMeta
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
 import { getItemIdentifierSchema } from '../../../../common/schemas/getItemIdentifierSchema';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { jsonSchema } from 'uuidv4';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import typer from 'content-type';
@@ -39,7 +40,7 @@ const defer = {
     priorityQueueStore
   }: {
     applicationDefinition: ApplicationDefinition;
-    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   }): WolkenkitRequestHandler {
     const requestBodySchema = new Value(defer.request.body),
           responseBodySchema = new Value(defer.response.body);

--- a/lib/apis/awaitCommandWithMetadata/http/v2/index.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/index.ts
@@ -7,6 +7,7 @@ import { CommandWithMetadata } from '../../../../common/elements/CommandWithMeta
 import { CorsOrigin } from 'get-cors-origin';
 import { defer } from './defer';
 import { getApiBase } from '../../../base/getApiBase';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import { renewLock } from './renewLock';
 import { Subscriber } from '../../../../messaging/pubSub/Subscriber';
@@ -21,7 +22,7 @@ const getV2 = async function ({
 }: {
   applicationDefinition: ApplicationDefinition;
   corsOrigin: CorsOrigin;
-  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   newCommandSubscriber: Subscriber<object>;
   newCommandSubscriberChannel: string;
   heartbeatInterval?: number;

--- a/lib/apis/awaitCommandWithMetadata/http/v2/renewLock.ts
+++ b/lib/apis/awaitCommandWithMetadata/http/v2/renewLock.ts
@@ -4,6 +4,7 @@ import { CommandWithMetadata } from '../../../../common/elements/CommandWithMeta
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
 import { getItemIdentifierSchema } from '../../../../common/schemas/getItemIdentifierSchema';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { jsonSchema } from 'uuidv4';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import typer from 'content-type';
@@ -38,7 +39,7 @@ const renewLock = {
     priorityQueueStore
   }: {
     applicationDefinition: ApplicationDefinition;
-    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+    priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   }): WolkenkitRequestHandler {
     const requestBodySchema = new Value(renewLock.request.body),
           responseBodySchema = new Value(renewLock.response.body);

--- a/lib/apis/handleCommand/OnCancelCommand.ts
+++ b/lib/apis/handleCommand/OnCancelCommand.ts
@@ -1,0 +1,5 @@
+import { ItemIdentifierWithClient } from '../../common/elements/ItemIdentifierWithClient';
+
+export type OnCancelCommand = ({ commandIdentifierWithClient }: {
+  commandIdentifierWithClient: ItemIdentifierWithClient;
+}) => Promise<void>;

--- a/lib/apis/handleCommand/http/index.ts
+++ b/lib/apis/handleCommand/http/index.ts
@@ -4,17 +4,20 @@ import { CorsOrigin } from 'get-cors-origin';
 import { getApiDefinitions } from './getApiDefinitions';
 import { getV2 } from './v2';
 import { IdentityProvider } from 'limes';
+import { OnCancelCommand } from '../OnCancelCommand';
 import { OnReceiveCommand } from '../OnReceiveCommand';
 import express, { Application } from 'express';
 
 const getApi = async function ({
   corsOrigin,
   onReceiveCommand,
+  onCancelCommand,
   applicationDefinition,
   identityProviders
 }: {
   corsOrigin: CorsOrigin;
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
   applicationDefinition: ApplicationDefinition;
   identityProviders: IdentityProvider[];
 }): Promise<{ api: Application; getApiDefinitions: (basePath: string) => ApiDefinition[] }> {
@@ -23,6 +26,7 @@ const getApi = async function ({
   const v2 = await getV2({
     corsOrigin,
     onReceiveCommand,
+    onCancelCommand,
     applicationDefinition,
     identityProviders
   });

--- a/lib/apis/handleCommand/http/v2/Client.ts
+++ b/lib/apis/handleCommand/http/v2/Client.ts
@@ -5,6 +5,7 @@ import { CommandDescription } from '../../../../common/application/CommandDescri
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
 import { HttpClient } from '../../../shared/HttpClient';
+import { ItemIdentifier } from '../../../../common/elements/ItemIdentifier';
 
 const logger = flaschenpost.getLogger();
 
@@ -65,6 +66,47 @@ class Client extends HttpClient {
       default: {
         logger.error('An unknown error occured.', { ex: data, status });
 
+        throw new errors.UnknownError();
+      }
+    }
+  }
+
+  public async cancelCommand ({ commandIdentifier }: {
+    commandIdentifier: ItemIdentifier;
+  }): Promise<void> {
+    const { status, data } = await axios({
+      method: 'post',
+      url: `${this.url}/cancel`,
+      data: commandIdentifier,
+      validateStatus (): boolean {
+        return true;
+      }
+    });
+
+    switch (status) {
+      case 200: {
+        return;
+      }
+      case 400: {
+        switch (data.code) {
+          case 'ECONTEXTNOTFOUND': {
+            throw new errors.ContextNotFound(data.message);
+          }
+          case 'EAGGREGATENOTFOUND': {
+            throw new errors.AggregateNotFound(data.message);
+          }
+          case 'ECOMMANDNOTFOUND': {
+            throw new errors.CommandNotFound(data.message);
+          }
+          default: {
+            throw new errors.UnknownError();
+          }
+        }
+      }
+      case 404: {
+        throw new errors.ItemNotFound(data.message);
+      }
+      default: {
         throw new errors.UnknownError();
       }
     }

--- a/lib/apis/handleCommand/http/v2/cancelCommand.ts
+++ b/lib/apis/handleCommand/http/v2/cancelCommand.ts
@@ -21,7 +21,7 @@ const cancelCommand = {
     body: getItemIdentifierSchema()
   },
   response: {
-    statusCodes: [ 200, 400, 401, 415 ],
+    statusCodes: [ 200, 400, 401, 404, 415 ],
     body: { type: 'object' }
   },
 

--- a/lib/apis/handleCommand/http/v2/cancelCommand.ts
+++ b/lib/apis/handleCommand/http/v2/cancelCommand.ts
@@ -1,0 +1,129 @@
+import { ApplicationDefinition } from '../../../../common/application/ApplicationDefinition';
+import { ClientMetadata } from '../../../../common/utils/http/ClientMetadata';
+import { errors } from '../../../../common/errors';
+import { flaschenpost } from 'flaschenpost';
+import { getItemIdentifierSchema } from '../../../../common/schemas/getItemIdentifierSchema';
+import { ItemIdentifier } from '../../../../common/elements/ItemIdentifier';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { OnCancelCommand } from '../../OnCancelCommand';
+import typer from 'content-type';
+import { validateItemIdentifier } from '../../../../common/validators/validateItemIdentifier';
+import { Value } from 'validate-value';
+import { WolkenkitRequestHandler } from '../../../base/WolkenkitRequestHandler';
+
+const logger = flaschenpost.getLogger();
+
+const cancelCommand = {
+  description: 'Cancels a command that has not been processed yet.',
+  path: 'cancel',
+
+  request: {
+    body: getItemIdentifierSchema()
+  },
+  response: {
+    statusCodes: [ 200, 400, 401, 415 ],
+    body: { type: 'object' }
+  },
+
+  getHandler ({ onCancelCommand, applicationDefinition }: {
+    onCancelCommand: OnCancelCommand;
+    applicationDefinition: ApplicationDefinition;
+  }): WolkenkitRequestHandler {
+    const requestBodySchema = new Value(cancelCommand.request.body),
+          responseBodySchema = new Value(cancelCommand.response.body);
+
+    return async function (req, res): Promise<any> {
+      if (!req.token || !req.user) {
+        const ex = new errors.NotAuthenticatedError('Client information missing in request.');
+
+        res.status(401).json({
+          code: ex.code,
+          message: ex.message
+        });
+
+        throw ex;
+      }
+
+      try {
+        const contentType = typer.parse(req);
+
+        if (contentType.type !== 'application/json') {
+          throw new errors.RequestMalformed();
+        }
+      } catch {
+        const ex = new errors.RequestMalformed('Header content-type must be application/json.');
+
+        res.status(415).json({
+          code: ex.code,
+          message: ex.message
+        });
+
+        return;
+      }
+
+      try {
+        requestBodySchema.validate(req.body);
+      } catch (ex) {
+        const error = new errors.RequestMalformed(ex.message);
+
+        res.status(400).json({
+          code: error.code,
+          message: error.message
+        });
+
+        return;
+      }
+
+      const commandIdentifier: ItemIdentifier = req.body;
+
+      try {
+        validateItemIdentifier({ itemIdentifier: commandIdentifier, applicationDefinition, itemType: 'command' });
+      } catch (ex) {
+        res.status(400).json({
+          code: ex.code,
+          message: ex.message
+        });
+
+        return;
+      }
+
+      const commandIdentifierWithClient: ItemIdentifierWithClient = {
+        ...commandIdentifier,
+        client: new ClientMetadata({ req })
+      };
+
+      logger.info('Received request to cancel command.', { commandIdentifierWithClient });
+
+      try {
+        await onCancelCommand({ commandIdentifierWithClient });
+
+        const response = {};
+
+        responseBodySchema.validate(response);
+
+        res.status(200).json(response);
+      } catch (ex) {
+        switch (ex.code) {
+          case 'EITEMNOTFOUND': {
+            return res.status(404).json({
+              code: ex.code,
+              message: ex.message
+            });
+          }
+          default: {
+            logger.error('Unknown error occured.', { ex });
+
+            const error = new errors.UnknownError();
+
+            res.status(500).json({
+              code: error.code,
+              message: error.message
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export { cancelCommand };

--- a/lib/apis/handleCommand/http/v2/index.ts
+++ b/lib/apis/handleCommand/http/v2/index.ts
@@ -1,21 +1,25 @@
 import { Application } from 'express';
 import { ApplicationDefinition } from '../../../../common/application/ApplicationDefinition';
+import { cancelCommand } from './cancelCommand';
 import { CorsOrigin } from 'get-cors-origin';
 import { getApiBase } from '../../../base/getApiBase';
 import { getAuthenticationMiddleware } from '../../../base/getAuthenticationMiddleware';
 import { getDescription } from './getDescription';
 import { IdentityProvider } from 'limes';
+import { OnCancelCommand } from '../../OnCancelCommand';
 import { OnReceiveCommand } from '../../OnReceiveCommand';
 import { postCommand } from './postCommand';
 
 const getV2 = async function ({
   corsOrigin,
   onReceiveCommand,
+  onCancelCommand,
   applicationDefinition,
   identityProviders
 }: {
   corsOrigin: CorsOrigin;
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
   applicationDefinition: ApplicationDefinition;
   identityProviders: IdentityProvider[];
 }): Promise<{ api: Application }> {
@@ -40,6 +44,11 @@ const getV2 = async function ({
 
   api.post(`/${postCommand.path}`, authenticationMiddleware, postCommand.getHandler({
     onReceiveCommand,
+    applicationDefinition
+  }));
+
+  api.post(`/${cancelCommand.path}`, authenticationMiddleware, cancelCommand.getHandler({
+    onCancelCommand,
     applicationDefinition
   }));
 

--- a/lib/apis/handleCommandWithMetadata/OnCancelCommand.ts
+++ b/lib/apis/handleCommandWithMetadata/OnCancelCommand.ts
@@ -1,0 +1,5 @@
+import { ItemIdentifierWithClient } from '../../common/elements/ItemIdentifierWithClient';
+
+export type OnCancelCommand = ({ commandIdentifierWithClient }: {
+  commandIdentifierWithClient: ItemIdentifierWithClient;
+}) => Promise<void>;

--- a/lib/apis/handleCommandWithMetadata/http/index.ts
+++ b/lib/apis/handleCommandWithMetadata/http/index.ts
@@ -1,16 +1,19 @@
 import { ApplicationDefinition } from '../../../common/application/ApplicationDefinition';
 import { CorsOrigin } from 'get-cors-origin';
 import { getV2 } from './v2';
+import { OnCancelCommand } from '../OnCancelCommand';
 import { OnReceiveCommand } from '../OnReceiveCommand';
 import express, { Application } from 'express';
 
 const getApi = async function ({
   corsOrigin,
   onReceiveCommand,
+  onCancelCommand,
   applicationDefinition
 }: {
   corsOrigin: CorsOrigin;
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
   applicationDefinition: ApplicationDefinition;
 }): Promise<{ api: Application }> {
   const api = express();
@@ -18,6 +21,7 @@ const getApi = async function ({
   const v2 = await getV2({
     corsOrigin,
     onReceiveCommand,
+    onCancelCommand,
     applicationDefinition
   });
 

--- a/lib/apis/handleCommandWithMetadata/http/v2/Client.ts
+++ b/lib/apis/handleCommandWithMetadata/http/v2/Client.ts
@@ -4,6 +4,7 @@ import { CommandWithMetadata } from '../../../../common/elements/CommandWithMeta
 import { errors } from '../../../../common/errors';
 import { flaschenpost } from 'flaschenpost';
 import { HttpClient } from '../../../shared/HttpClient';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 
 const logger = flaschenpost.getLogger();
 
@@ -49,6 +50,47 @@ class Client extends HttpClient {
       default: {
         logger.error('An unknown error occured.', { ex: data, status });
 
+        throw new errors.UnknownError();
+      }
+    }
+  }
+
+  public async cancelCommand ({ commandIdentifierWithClient }: {
+    commandIdentifierWithClient: ItemIdentifierWithClient;
+  }): Promise<void> {
+    const { status, data } = await axios({
+      method: 'post',
+      url: `${this.url}/cancel`,
+      data: commandIdentifierWithClient,
+      validateStatus (): boolean {
+        return true;
+      }
+    });
+
+    switch (status) {
+      case 200: {
+        return;
+      }
+      case 400: {
+        switch (data.code) {
+          case 'ECONTEXTNOTFOUND': {
+            throw new errors.ContextNotFound(data.message);
+          }
+          case 'EAGGREGATENOTFOUND': {
+            throw new errors.AggregateNotFound(data.message);
+          }
+          case 'ECOMMANDNOTFOUND': {
+            throw new errors.CommandNotFound(data.message);
+          }
+          default: {
+            throw new errors.UnknownError();
+          }
+        }
+      }
+      case 404: {
+        throw new errors.ItemNotFound(data.message);
+      }
+      default: {
         throw new errors.UnknownError();
       }
     }

--- a/lib/apis/handleCommandWithMetadata/http/v2/cancelCommand.ts
+++ b/lib/apis/handleCommandWithMetadata/http/v2/cancelCommand.ts
@@ -1,0 +1,111 @@
+import { ApplicationDefinition } from '../../../../common/application/ApplicationDefinition';
+import { errors } from '../../../../common/errors';
+import { flaschenpost } from 'flaschenpost';
+import { getItemIdentifierWithClientSchema } from '../../../../common/schemas/getItemIdentifierWithClientSchema';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { OnCancelCommand } from '../../OnCancelCommand';
+import typer from 'content-type';
+import { validateItemIdentifier } from '../../../../common/validators/validateItemIdentifier';
+import { Value } from 'validate-value';
+import { WolkenkitRequestHandler } from '../../../base/WolkenkitRequestHandler';
+
+const logger = flaschenpost.getLogger();
+
+const cancelCommand = {
+  description: 'Cancels a command that has not been processed yet.',
+  path: 'cancel',
+
+  request: {
+    body: getItemIdentifierWithClientSchema()
+  },
+  response: {
+    statusCodes: [ 200, 400, 415 ],
+    body: { type: 'object' }
+  },
+
+  getHandler ({ onCancelCommand, applicationDefinition }: {
+    onCancelCommand: OnCancelCommand;
+    applicationDefinition: ApplicationDefinition;
+  }): WolkenkitRequestHandler {
+    const requestBodySchema = new Value(cancelCommand.request.body),
+          responseBodySchema = new Value(cancelCommand.response.body);
+
+    return async function (req, res): Promise<any> {
+      try {
+        const contentType = typer.parse(req);
+
+        if (contentType.type !== 'application/json') {
+          throw new errors.RequestMalformed();
+        }
+      } catch {
+        const ex = new errors.RequestMalformed('Header content-type must be application/json.');
+
+        res.status(415).json({
+          code: ex.code,
+          message: ex.message
+        });
+
+        return;
+      }
+
+      try {
+        requestBodySchema.validate(req.body);
+      } catch (ex) {
+        const error = new errors.RequestMalformed(ex.message);
+
+        res.status(400).json({
+          code: error.code,
+          message: error.message
+        });
+
+        return;
+      }
+
+      const commandIdentifierWithClient: ItemIdentifierWithClient = req.body;
+
+      try {
+        validateItemIdentifier({ itemIdentifier: commandIdentifierWithClient, applicationDefinition, itemType: 'command' });
+      } catch (ex) {
+        res.status(400).json({
+          code: ex.code,
+          message: ex.message
+        });
+
+        return;
+      }
+
+      logger.info('Received request to cancel command.', { commandIdentifierWithClient });
+
+      try {
+        await onCancelCommand({ commandIdentifierWithClient });
+
+        const response = {};
+
+        responseBodySchema.validate(response);
+
+        res.status(200).json(response);
+      } catch (ex) {
+        switch (ex.code) {
+          case 'EITEMNOTFOUND': {
+            return res.status(404).json({
+              code: ex.code,
+              message: ex.message
+            });
+          }
+          default: {
+            logger.error('Unknown error occured.', { ex });
+
+            const error = new errors.UnknownError();
+
+            res.status(500).json({
+              code: error.code,
+              message: error.message
+            });
+          }
+        }
+      }
+    };
+  }
+};
+
+export { cancelCommand };

--- a/lib/apis/handleCommandWithMetadata/http/v2/cancelCommand.ts
+++ b/lib/apis/handleCommandWithMetadata/http/v2/cancelCommand.ts
@@ -19,7 +19,7 @@ const cancelCommand = {
     body: getItemIdentifierWithClientSchema()
   },
   response: {
-    statusCodes: [ 200, 400, 415 ],
+    statusCodes: [ 200, 400, 404, 415 ],
     body: { type: 'object' }
   },
 

--- a/lib/apis/handleCommandWithMetadata/http/v2/index.ts
+++ b/lib/apis/handleCommandWithMetadata/http/v2/index.ts
@@ -1,17 +1,21 @@
 import { Application } from 'express';
 import { ApplicationDefinition } from '../../../../common/application/ApplicationDefinition';
+import { cancelCommand } from './cancelCommand';
 import { CorsOrigin } from 'get-cors-origin';
 import { getApiBase } from '../../../base/getApiBase';
+import { OnCancelCommand } from '../../OnCancelCommand';
 import { OnReceiveCommand } from '../../OnReceiveCommand';
 import { postCommand } from './postCommand';
 
 const getV2 = async function ({
   corsOrigin,
   onReceiveCommand,
+  onCancelCommand,
   applicationDefinition
 }: {
   corsOrigin: CorsOrigin;
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
   applicationDefinition: ApplicationDefinition;
 }): Promise<{ api: Application }> {
   const api = await getApiBase({
@@ -27,6 +31,11 @@ const getV2 = async function ({
 
   api.post(`/${postCommand.path}`, postCommand.getHandler({
     onReceiveCommand,
+    applicationDefinition
+  }));
+
+  api.post(`/${cancelCommand.path}`, cancelCommand.getHandler({
+    onCancelCommand,
     applicationDefinition
   }));
 

--- a/lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata.ts
+++ b/lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata.ts
@@ -1,0 +1,16 @@
+import { CommandData } from '../elements/CommandData';
+import { CommandWithMetadata } from '../elements/CommandWithMetadata';
+import { DoesIdentifierMatchItem } from '../../stores/priorityQueueStore/DoesIdentifierMatchItem';
+import { isEqual } from 'lodash';
+import { ItemIdentifierWithClient } from '../elements/ItemIdentifierWithClient';
+
+const doesItemIdentifierWithClientMatchCommandWithMetadata: DoesIdentifierMatchItem<CommandWithMetadata<CommandData>, ItemIdentifierWithClient> =
+    function ({ item, itemIdentifier }): boolean {
+      return isEqual(item.contextIdentifier, itemIdentifier.contextIdentifier) &&
+        isEqual(item.aggregateIdentifier, itemIdentifier.aggregateIdentifier) &&
+        item.name === itemIdentifier.name &&
+        item.id === itemIdentifier.id &&
+        isEqual(item.metadata.client, itemIdentifier.client);
+    };
+
+export { doesItemIdentifierWithClientMatchCommandWithMetadata };

--- a/lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata.ts
+++ b/lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata.ts
@@ -10,7 +10,7 @@ const doesItemIdentifierWithClientMatchCommandWithMetadata: DoesIdentifierMatchI
         isEqual(item.aggregateIdentifier, itemIdentifier.aggregateIdentifier) &&
         item.name === itemIdentifier.name &&
         item.id === itemIdentifier.id &&
-        isEqual(item.metadata.client, itemIdentifier.client);
+        isEqual(item.metadata.client.user, itemIdentifier.client.user);
     };
 
 export { doesItemIdentifierWithClientMatchCommandWithMetadata };

--- a/lib/common/elements/ItemIdentifierWithClient.ts
+++ b/lib/common/elements/ItemIdentifierWithClient.ts
@@ -1,0 +1,6 @@
+import { Client } from './Client';
+import { ItemIdentifier } from './ItemIdentifier';
+
+export interface ItemIdentifierWithClient extends ItemIdentifier {
+  client: Client;
+}

--- a/lib/common/schemas/getClientSchema.ts
+++ b/lib/common/schemas/getClientSchema.ts
@@ -1,0 +1,31 @@
+import { Schema } from '../elements/Schema';
+
+const getClientSchema = function (): Schema {
+  return {
+    type: 'object',
+    properties: {
+      token: { type: 'string', minLength: 1 },
+      user: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', minLength: 1 },
+          claims: {
+            type: 'object',
+            properties: {
+              sub: { type: 'string', minLength: 1 }
+            },
+            required: [ 'sub' ],
+            additionalProperties: true
+          }
+        },
+        required: [ 'id', 'claims' ],
+        additionalProperties: false
+      },
+      ip: { type: 'string', minLength: 1 }
+    },
+    required: [ 'token', 'user', 'ip' ],
+    additionalProperties: false
+  };
+};
+
+export { getClientSchema };

--- a/lib/common/schemas/getCommandWithMetadataSchema.ts
+++ b/lib/common/schemas/getCommandWithMetadataSchema.ts
@@ -1,3 +1,4 @@
+import { getClientSchema } from './getClientSchema';
 import { jsonSchema } from 'uuidv4';
 import { Schema } from '../elements/Schema';
 
@@ -36,31 +37,7 @@ const getCommandWithMetadataSchema = function (): Schema {
           causationId: jsonSchema.v4 as Schema,
           correlationId: jsonSchema.v4 as Schema,
           timestamp: { type: 'number' },
-          client: {
-            type: 'object',
-            properties: {
-              token: { type: 'string', minLength: 1 },
-              user: {
-                type: 'object',
-                properties: {
-                  id: { type: 'string', minLength: 1 },
-                  claims: {
-                    type: 'object',
-                    properties: {
-                      sub: { type: 'string', minLength: 1 }
-                    },
-                    required: [ 'sub' ],
-                    additionalProperties: true
-                  }
-                },
-                required: [ 'id', 'claims' ],
-                additionalProperties: false
-              },
-              ip: { type: 'string', minLength: 1 }
-            },
-            required: [ 'token', 'user', 'ip' ],
-            additionalProperties: false
-          },
+          client: getClientSchema(),
           initiator: {
             type: 'object',
             properties: {

--- a/lib/common/schemas/getItemIdentifierWithClientSchema.ts
+++ b/lib/common/schemas/getItemIdentifierWithClientSchema.ts
@@ -1,0 +1,41 @@
+import { getClientSchema } from './getClientSchema';
+import { jsonSchema } from 'uuidv4';
+import { Schema } from '../elements/Schema';
+
+const getItemIdentifierWithClientSchema = function (): Schema {
+  return {
+    type: 'object',
+    properties: {
+      contextIdentifier: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1, format: 'alphanumeric' }
+        },
+        required: [ 'name' ],
+        additionalProperties: false
+      },
+      aggregateIdentifier: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', minLength: 1, format: 'alphanumeric' },
+          id: jsonSchema.v4 as Schema
+        },
+        required: [ 'name', 'id' ],
+        additionalProperties: false
+      },
+      id: jsonSchema.v4 as Schema,
+      name: { type: 'string', minLength: 1, format: 'alphanumeric' },
+      client: getClientSchema()
+    },
+    required: [
+      'contextIdentifier',
+      'aggregateIdentifier',
+      'id',
+      'name',
+      'client'
+    ],
+    additionalProperties: false
+  };
+};
+
+export { getItemIdentifierWithClientSchema };

--- a/lib/common/validators/validateItemIdentifier.ts
+++ b/lib/common/validators/validateItemIdentifier.ts
@@ -4,16 +4,19 @@ import { ItemIdentifier } from '../elements/ItemIdentifier';
 
 const validateItemIdentifier = function ({
   itemIdentifier,
-  applicationDefinition
+  applicationDefinition,
+  itemType
 }: {
   itemIdentifier: ItemIdentifier;
   applicationDefinition: ApplicationDefinition;
+  itemType?: 'command' | 'domain-event';
 }): void {
   const contextDefinitions = applicationDefinition.domain;
 
   const {
     contextIdentifier: { name: contextName },
-    aggregateIdentifier: { name: aggregateName }
+    aggregateIdentifier: { name: aggregateName },
+    name
   } = itemIdentifier;
 
   if (!(contextName in contextDefinitions)) {
@@ -21,6 +24,26 @@ const validateItemIdentifier = function ({
   }
   if (!(aggregateName in contextDefinitions[contextName])) {
     throw new errors.AggregateNotFound(`Aggregate '${contextName}.${aggregateName}' not found.`);
+  }
+
+  switch (itemType) {
+    case 'command': {
+      if (!(name in contextDefinitions[contextName][aggregateName].commandHandlers)) {
+        throw new errors.CommandNotFound(`Command '${contextName}.${aggregateName}.${name}' not found.`);
+      }
+
+      break;
+    }
+    case 'domain-event': {
+      if (!(name in contextDefinitions[contextName][aggregateName].domainEventHandlers)) {
+        throw new errors.DomainEventNotFound(`Domain event '${contextName}.${aggregateName}.${name}' not found.`);
+      }
+
+      break;
+    }
+    default: {
+      break;
+    }
   }
 };
 

--- a/lib/runtimes/microservice/processes/command/app.ts
+++ b/lib/runtimes/microservice/processes/command/app.ts
@@ -6,6 +6,7 @@ import { getApi } from './getApi';
 import { getApplicationDefinition } from '../../../../common/application/getApplicationDefinition';
 import { getConfiguration } from './getConfiguration';
 import { getIdentityProviders } from '../../../shared/getIdentityProviders';
+import { getOnCancelCommand } from './getOnCancelCommand';
 import { getOnReceiveCommand } from './getOnReceiveCommand';
 import http from 'http';
 import { registerExceptionHandler } from '../../../../common/utils/process/registerExceptionHandler';
@@ -35,18 +36,19 @@ import { runHealthServer } from '../../../shared/runHealthServer';
       path: '/handle-command/v2'
     });
 
-    const onReceiveCommand = getOnReceiveCommand({
-      dispatcher: {
-        client: dispatcherClient,
-        retries: configuration.dispatcherRetries
-      }
-    });
+    const dispatcher = {
+      client: dispatcherClient,
+      retries: configuration.dispatcherRetries
+    };
+    const onReceiveCommand = getOnReceiveCommand({ dispatcher });
+    const onCancelCommand = getOnCancelCommand({ dispatcher });
 
     const { api } = await getApi({
       configuration,
       applicationDefinition,
       identityProviders,
-      onReceiveCommand
+      onReceiveCommand,
+      onCancelCommand
     });
 
     await runHealthServer({ corsOrigin: configuration.healthCorsOrigin, port: configuration.healthPort });

--- a/lib/runtimes/microservice/processes/command/getApi.ts
+++ b/lib/runtimes/microservice/processes/command/getApi.ts
@@ -4,6 +4,7 @@ import { getCorsOrigin } from 'get-cors-origin';
 import { getApi as getHandleCommandApi } from '../../../../apis/handleCommand/http';
 import { getApi as getOpenApiApi } from '../../../../apis/openApi/http';
 import { IdentityProvider } from 'limes';
+import { OnCancelCommand } from '../../../../apis/handleCommand/OnCancelCommand';
 import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
 import express, { Application } from 'express';
 
@@ -11,18 +12,21 @@ const getApi = async function ({
   configuration,
   applicationDefinition,
   identityProviders,
-  onReceiveCommand
+  onReceiveCommand,
+  onCancelCommand
 }: {
   configuration: Configuration;
   applicationDefinition: ApplicationDefinition;
   identityProviders: IdentityProvider[];
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
 }): Promise<{ api: Application }> {
   const corsOrigin = getCorsOrigin(configuration.commandCorsOrigin);
 
   const { api: handleCommandApi, getApiDefinitions: getHandleCommandApiDefinitions } = await getHandleCommandApi({
     corsOrigin,
     onReceiveCommand,
+    onCancelCommand,
     applicationDefinition,
     identityProviders
   });

--- a/lib/runtimes/microservice/processes/command/getOnCancelCommand.ts
+++ b/lib/runtimes/microservice/processes/command/getOnCancelCommand.ts
@@ -1,0 +1,27 @@
+import { Dispatcher } from './Dispatcher';
+import { errors } from '../../../../common/errors';
+import { flaschenpost } from 'flaschenpost';
+import { OnCancelCommand } from '../../../../apis/handleCommand/OnCancelCommand';
+
+const logger = flaschenpost.getLogger();
+
+const getOnCancelCommand = function ({ dispatcher }: {
+  dispatcher: Dispatcher;
+}): OnCancelCommand {
+  return async function ({ commandIdentifierWithClient }): Promise<void> {
+    try {
+      await dispatcher.client.cancelCommand({ commandIdentifierWithClient });
+
+      logger.info('Cancelled command in dispatcher.', { commandIdentifierWithClient });
+    } catch (ex) {
+      logger.error('Failed to cancel command in dispatcher.', { commandIdentifierWithClient, ex });
+
+      throw new errors.RequestFailed('Failed to cancel command in dispatcher.', {
+        cause: ex,
+        data: { commandIdentifierWithClient }
+      });
+    }
+  };
+};
+
+export { getOnCancelCommand };

--- a/lib/runtimes/microservice/processes/dispatcher/getApi.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getApi.ts
@@ -5,6 +5,8 @@ import { Configuration } from './Configuration';
 import { getApi as getAwaitCommandWithMetadataApi } from '../../../../apis/awaitCommandWithMetadata/http';
 import { getCorsOrigin } from 'get-cors-origin';
 import { getApi as getHandleCommandWithMetadataApi } from '../../../../apis/handleCommandWithMetadata/http';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { OnCancelCommand } from '../../../../apis/handleCommandWithMetadata/OnCancelCommand';
 import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import { Subscriber } from '../../../../messaging/pubSub/Subscriber';
@@ -16,18 +18,21 @@ const getApi = async function ({
   priorityQueueStore,
   newCommandSubscriber,
   newCommandPubSubChannel,
-  onReceiveCommand
+  onReceiveCommand,
+  onCancelCommand
 }: {
   configuration: Configuration;
   applicationDefinition: ApplicationDefinition;
-  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   newCommandSubscriber: Subscriber<object>;
   newCommandPubSubChannel: string;
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
 }): Promise<{ api: Application }> {
   const { api: handleCommandApi } = await getHandleCommandWithMetadataApi({
     corsOrigin: getCorsOrigin(configuration.handleCommandCorsOrigin),
     onReceiveCommand,
+    onCancelCommand,
     applicationDefinition
   });
 

--- a/lib/runtimes/microservice/processes/dispatcher/getOnCancelCommand.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getOnCancelCommand.ts
@@ -7,9 +7,7 @@ import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/Priori
 
 const logger = flaschenpost.getLogger();
 
-const getOnCancelCommand = function ({
-  priorityQueueStore
-}: {
+const getOnCancelCommand = function ({ priorityQueueStore }: {
   priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
 }): OnCancelCommand {
   return async function ({ commandIdentifierWithClient }): Promise<void> {

--- a/lib/runtimes/microservice/processes/dispatcher/getOnCancelCommand.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getOnCancelCommand.ts
@@ -1,0 +1,25 @@
+import { CommandData } from '../../../../common/elements/CommandData';
+import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { flaschenpost } from 'flaschenpost';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { OnCancelCommand } from '../../../../apis/handleCommand/OnCancelCommand';
+import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
+
+const logger = flaschenpost.getLogger();
+
+const getOnCancelCommand = function ({
+  priorityQueueStore
+}: {
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
+}): OnCancelCommand {
+  return async function ({ commandIdentifierWithClient }): Promise<void> {
+    await priorityQueueStore.remove({
+      itemIdentifier: commandIdentifierWithClient,
+      discriminator: commandIdentifierWithClient.aggregateIdentifier.id
+    });
+
+    logger.debug('Cancelled command by removing it from the priority queue.', { commandIdentifierWithClient });
+  };
+};
+
+export { getOnCancelCommand };

--- a/lib/runtimes/microservice/processes/dispatcher/getOnReceiveCommand.ts
+++ b/lib/runtimes/microservice/processes/dispatcher/getOnReceiveCommand.ts
@@ -1,6 +1,7 @@
 import { CommandData } from '../../../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
 import { flaschenpost } from 'flaschenpost';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 import { Publisher } from '../../../../messaging/pubSub/Publisher';
@@ -12,7 +13,7 @@ const getOnReceiveCommand = function ({
   newCommandPublisher,
   newCommandPubSubChannel
 }: {
-  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   newCommandPublisher: Publisher<object>;
   newCommandPubSubChannel: string;
 }): OnReceiveCommand {

--- a/lib/runtimes/singleProcess/processes/main/PriorityQueue.ts
+++ b/lib/runtimes/singleProcess/processes/main/PriorityQueue.ts
@@ -1,8 +1,9 @@
 import { CommandData } from '../../../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
 import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
 
 export interface PriorityQueue {
-  store: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+  store: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
   renewalInterval: number;
 }

--- a/lib/runtimes/singleProcess/processes/main/getApi.ts
+++ b/lib/runtimes/singleProcess/processes/main/getApi.ts
@@ -7,6 +7,7 @@ import { getApi as getObserveDomainEventsApi } from '../../../../apis/observeDom
 import { getApi as getOpenApiApi } from '../../../../apis/openApi/http';
 import { IdentityProvider } from 'limes';
 import { InitializeGraphQlOnServer } from '../../../../apis/graphql/InitializeGraphQlOnServer';
+import { OnCancelCommand } from '../../../../apis/handleCommand/OnCancelCommand';
 import { OnReceiveCommand } from '../../../../apis/handleCommand/OnReceiveCommand';
 import { PublishDomainEvent } from '../../../../apis/observeDomainEvents/PublishDomainEvent';
 import { Repository } from '../../../../common/domain/Repository';
@@ -17,12 +18,14 @@ const getApi = async function ({
   applicationDefinition,
   identityProviders,
   onReceiveCommand,
+  onCancelCommand,
   repository
 }: {
   configuration: Configuration;
   applicationDefinition: ApplicationDefinition;
   identityProviders: IdentityProvider[];
   onReceiveCommand: OnReceiveCommand;
+  onCancelCommand: OnCancelCommand;
   repository: Repository;
 }): Promise<{
     api: Application;
@@ -50,6 +53,7 @@ const getApi = async function ({
     const { api: handleCommandApi, getApiDefinitions: getHandleCommandApiDefinitions } = await getHandleCommandApi({
       corsOrigin,
       onReceiveCommand,
+      onCancelCommand,
       applicationDefinition,
       identityProviders
     });

--- a/lib/stores/priorityQueueStore/DoesIdentifierMatchItem.ts
+++ b/lib/stores/priorityQueueStore/DoesIdentifierMatchItem.ts
@@ -1,0 +1,4 @@
+export type DoesIdentifierMatchItem<TItem, TItemIdentifier> = ({ item, itemIdentifier }: {
+  item: TItem;
+  itemIdentifier: TItemIdentifier;
+}) => boolean;

--- a/lib/stores/priorityQueueStore/PriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/PriorityQueueStore.ts
@@ -1,7 +1,7 @@
 // The priority queues implementing this interface are based on a heap data
 // structure, where items with smaller priorities tend to become closer to the
 // root node. Hence, this represents a min-heap.
-export interface PriorityQueueStore<TItem> {
+export interface PriorityQueueStore<TItem, TItemIdentifier> {
   enqueue ({ item, discriminator, priority }: {
     item: TItem;
     discriminator: string;
@@ -24,6 +24,11 @@ export interface PriorityQueueStore<TItem> {
     discriminator: string;
     token: string;
     priority: number;
+  }): Promise<void>;
+
+  remove ({ discriminator, itemIdentifier }: {
+    discriminator: string;
+    itemIdentifier: TItemIdentifier;
   }): Promise<void>;
 
   destroy (): Promise<void>;

--- a/lib/stores/priorityQueueStore/SqlServer/SqlServerPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/SqlServer/SqlServerPriorityQueueStore.ts
@@ -9,7 +9,6 @@ import { Queue } from './Queue';
 import { TableNames } from './TableNames';
 import { uuid } from 'uuidv4';
 import { ConnectionPool, Transaction, TYPES as Types } from 'mssql';
-import { runQuery } from '../../utils/mySql/runQuery';
 
 class SqlServerPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueueStore<TItem, TItemIdentifier> {
   protected tableNames: TableNames;

--- a/lib/stores/priorityQueueStore/SqlServer/SqlServerPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/SqlServer/SqlServerPriorityQueueStore.ts
@@ -1,3 +1,4 @@
+import { DoesIdentifierMatchItem } from '../DoesIdentifierMatchItem';
 import { errors } from '../../../common/errors';
 import { getIndexOfLeftChild } from '../shared/getIndexOfLeftChild';
 import { getIndexOfParent } from '../shared/getIndexOfParent';
@@ -8,11 +9,14 @@ import { Queue } from './Queue';
 import { TableNames } from './TableNames';
 import { uuid } from 'uuidv4';
 import { ConnectionPool, Transaction, TYPES as Types } from 'mssql';
+import { runQuery } from '../../utils/mySql/runQuery';
 
-class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
+class SqlServerPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueueStore<TItem, TItemIdentifier> {
   protected tableNames: TableNames;
 
   protected pool: ConnectionPool;
+
+  protected doesIdentifierMatchItem: DoesIdentifierMatchItem<TItem, TItemIdentifier>;
 
   protected expirationTime: number;
 
@@ -30,36 +34,44 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
     throw new Error('Connection closed unexpectedly.');
   }
 
-  protected constructor ({ tableNames, pool, expirationTime }: {
+  protected constructor ({ tableNames, pool, doesIdentifierMatchItem, expirationTime }: {
     tableNames: TableNames;
     pool: ConnectionPool;
+    doesIdentifierMatchItem: DoesIdentifierMatchItem<TItem, TItemIdentifier>;
     expirationTime: number;
   }) {
     this.tableNames = tableNames;
     this.pool = pool;
+    this.doesIdentifierMatchItem = doesIdentifierMatchItem;
     this.expirationTime = expirationTime;
     this.functionCallQueue = new PQueue({ concurrency: 1 });
   }
 
-  public static async create<TItem> ({
-    hostName,
-    port,
-    userName,
-    password,
-    database,
-    tableNames,
-    encryptConnection = false,
-    expirationTime = 15_000
+  public static async create<TItem, TItemIdentifier> ({
+    doesIdentifierMatchItem,
+    options: {
+      hostName,
+      port,
+      userName,
+      password,
+      database,
+      tableNames,
+      encryptConnection = false,
+      expirationTime = 15_000
+    }
   }: {
-    hostName: string;
-    port: number;
-    userName: string;
-    password: string;
-    database: string;
-    tableNames: TableNames;
-    encryptConnection?: boolean;
-    expirationTime?: number;
-  }): Promise<SqlServerPriorityQueueStore<TItem>> {
+    doesIdentifierMatchItem: DoesIdentifierMatchItem<TItem, TItemIdentifier>;
+    options: {
+      hostName: string;
+      port: number;
+      userName: string;
+      password: string;
+      database: string;
+      tableNames: TableNames;
+      encryptConnection?: boolean;
+      expirationTime?: number;
+    };
+  }): Promise<SqlServerPriorityQueueStore<TItem, TItemIdentifier>> {
     const pool = new ConnectionPool({
       server: hostName,
       port,
@@ -79,7 +91,12 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
 
     await pool.connect();
 
-    const priorityQueueStore = new SqlServerPriorityQueueStore<TItem>({ tableNames, pool, expirationTime });
+    const priorityQueueStore = new SqlServerPriorityQueueStore<TItem, TItemIdentifier>({
+      tableNames,
+      pool,
+      doesIdentifierMatchItem,
+      expirationTime
+    });
 
     try {
       await pool.query(`
@@ -244,30 +261,40 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
     }
   }
 
-  protected async removeInternal ({ transaction, discriminator }: {
+  protected async removeQueueInternal ({ transaction, discriminator }: {
     transaction: Transaction;
     discriminator: string;
   }): Promise<void> {
-    const queue = await this.getQueueByDiscriminator({ transaction, discriminator });
+    const requestOne = transaction.request();
 
-    if (!queue) {
-      throw new errors.InvalidOperation();
+    requestOne.input('discriminator', Types.NVarChar, discriminator);
+
+    const { recordset } = await requestOne.query(`
+      SELECT [indexInPriorityQueue]
+        FROM [${this.tableNames.priorityQueue}]
+        WHERE [discriminator] = @discriminator;
+    `);
+
+    if (recordset.length === 0) {
+      throw new errors.ItemNotFound();
     }
 
-    const request = transaction.request();
+    const requestTwo = transaction.request();
 
-    request.input('discriminator', Types.NVarChar, queue.discriminator);
-    request.input('index', Types.Int, queue.index);
+    requestTwo.input('discriminator', Types.NVarChar, discriminator);
+    requestTwo.input('index', Types.Int, recordset[0].indexInPriorityQueue);
 
-    const { rowsAffected, recordsets } = await request.query(`
-      DELETE FROM [${this.tableNames.priorityQueue}]
+    const { rowsAffected, recordsets } = await requestTwo.query(`
+      DELETE
+        FROM [${this.tableNames.priorityQueue}]
         WHERE [discriminator] = @discriminator;
       WITH [CTE] AS (
         SELECT TOP 1 *
           FROM [${this.tableNames.priorityQueue}]
           ORDER BY [indexInPriorityQueue] DESC
       ) UPDATE [CTE] SET [indexInPriorityQueue] = @index;
-      SELECT [discriminator] FROM [${this.tableNames.priorityQueue}]
+      SELECT [discriminator]
+        FROM [${this.tableNames.priorityQueue}]
         WHERE [indexInPriorityQueue] = @index;
     `);
 
@@ -297,7 +324,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
         FROM [${this.tableNames.priorityQueue}] AS [pq]
         JOIN [${this.tableNames.items}] AS [i]
           ON [pq].[discriminator] = [i].[discriminator]
-        WHERE [pq].[discriminator] = @discriminator AND [i].[indexInQueue] = 0;
+        WHERE [pq].[discriminator] = @discriminator
+          AND [i].[indexInQueue] = 0;
     `);
 
     if (recordset.length === 0) {
@@ -337,7 +365,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
         FROM [${this.tableNames.priorityQueue}] AS [pq]
         JOIN [${this.tableNames.items}] AS [i]
           ON [pq].[discriminator] = [i].[discriminator]
-        WHERE [pq].[indexInPriorityQueue] = @indexInPriorityQueue AND [i].[indexInQueue] = 0;
+        WHERE [pq].[indexInPriorityQueue] = @indexInPriorityQueue
+          AND [i].[indexInQueue] = 0;
     `);
 
     if (recordset.length === 0) {
@@ -369,7 +398,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
     request.input('discriminator', Types.NVarChar, discriminator);
 
     const { recordset } = await request.query(`
-      SELECT TOP 1 [item] FROM [${this.tableNames.items}]
+      SELECT TOP 1 [item]
+        FROM [${this.tableNames.items}]
         WHERE [discriminator] = @discriminator
         ORDER BY [indexInQueue] ASC;
     `);
@@ -415,7 +445,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
 
     const { recordset: [{ nextIndexInQueue }] } = await requestGetNextIndexInQueue.query(`
       SELECT COALESCE(MAX([indexInQueue]) + 1, 0) AS [nextIndexInQueue]
-        FROM [${this.tableNames.items}] WHERE [discriminator] = @discriminator;
+        FROM [${this.tableNames.items}]
+        WHERE [discriminator] = @discriminator;
     `);
 
     const requestInsertItem = transaction.request();
@@ -426,7 +457,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
     requestInsertItem.input('item', Types.NVarChar, JSON.stringify(item));
 
     await requestInsertItem.query(`
-      INSERT INTO [${this.tableNames.items}] ([discriminator], [indexInQueue], [priority], [item])
+      INSERT
+        INTO [${this.tableNames.items}] ([discriminator], [indexInQueue], [priority], [item])
         VALUES (@discriminator, @indexInQueue, @priority, @item);
     `);
 
@@ -444,7 +476,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
       requestInsertPriorityQueue.input('indexInPriorityQueue', Types.Int, nextIndexInPriorityQueue);
 
       await requestInsertPriorityQueue.query(`
-        INSERT INTO [${this.tableNames.priorityQueue}] ([discriminator], [indexInPriorityQueue])
+        INSERT
+          INTO [${this.tableNames.priorityQueue}] ([discriminator], [indexInPriorityQueue])
           VALUES (@discriminator, @indexInPriorityQueue);
       `);
     } catch (ex) {
@@ -489,7 +522,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
 
     const { recordset } = await requestSelect.query(`
       SELECT TOP 1 [discriminator] FROM [${this.tableNames.priorityQueue}]
-        WHERE [lockUntil] IS NULL OR [lockUntil] <= @now
+        WHERE [lockUntil] IS NULL
+           OR [lockUntil] <= @now
         ORDER BY [indexInPriorityQueue] ASC;
     `);
 
@@ -598,7 +632,8 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
 
     const { rowsAffected } = await requestDelete.query(`
       DELETE FROM [${this.tableNames.items}]
-        WHERE [discriminator] = @discriminator AND [indexInQueue] = 0;
+        WHERE [discriminator] = @discriminator
+          AND [indexInQueue] = 0;
       UPDATE [${this.tableNames.items}]
         SET [indexInQueue] = [indexInQueue] - 1
         WHERE [discriminator] = @discriminator;
@@ -622,7 +657,7 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
       return;
     }
 
-    await this.removeInternal({ transaction, discriminator: queue.discriminator });
+    await this.removeQueueInternal({ transaction, discriminator: queue.discriminator });
   }
 
   public async acknowledge ({ discriminator, token }: {
@@ -673,6 +708,102 @@ class SqlServerPriorityQueueStore<TItem> implements PriorityQueueStore<TItem> {
 
         try {
           await this.deferInternal({ transaction, discriminator, token, priority });
+          await transaction.commit();
+        } catch (ex) {
+          await transaction.rollback();
+          throw ex;
+        }
+      }
+    );
+  }
+
+  public async removeInternal ({ transaction, discriminator, itemIdentifier }: {
+    transaction: Transaction;
+    discriminator: string;
+    itemIdentifier: TItemIdentifier;
+  }): Promise<void> {
+    const queue = await this.getQueueByDiscriminator({ transaction, discriminator });
+
+    if (!queue) {
+      throw new errors.ItemNotFound();
+    }
+
+    const getItemsRequest = transaction.request();
+
+    getItemsRequest.input('discriminator', Types.NVarChar, discriminator);
+
+    const { recordset } = await getItemsRequest.query(`
+      SELECT [item]
+        FROM [${this.tableNames.items}]
+        WHERE [discriminator] = @discriminator
+        ORDER BY [indexInQueue] ASC;
+    `);
+
+    const items = recordset.map(({ item }: { item: string }): TItem => JSON.parse(item));
+
+    const foundItemIndex = items.findIndex((item: TItem): boolean => this.doesIdentifierMatchItem({ item, itemIdentifier }));
+
+    if (foundItemIndex === -1) {
+      throw new errors.ItemNotFound();
+    }
+
+    if (foundItemIndex === 0) {
+      if (queue?.lock && queue.lock.until > Date.now()) {
+        throw new errors.ItemNotFound();
+      }
+
+      if (items.length === 1) {
+        await this.removeQueueInternal({ transaction, discriminator });
+
+        return;
+      }
+
+      const removeItemRequest = transaction.request();
+
+      removeItemRequest.input('discriminator', Types.NVarChar, discriminator);
+
+      await removeItemRequest.query(`
+        DELETE
+          FROM [${this.tableNames.items}]
+          WHERE [discriminator] = @discriminator
+            AND [indexInQueue] = 0;
+        UPDATE [${this.tableNames.items}]
+          SET [indexInQueue] = [indexInQueue] - 1
+          WHERE [discriminator] = @discriminator;
+      `);
+
+      await this.repairDown({ transaction, discriminator: queue.discriminator });
+      await this.repairUp({ transaction, discriminator: queue.discriminator });
+
+      return;
+    }
+
+    const removeItemRequest = transaction.request();
+
+    removeItemRequest.input('discriminator', Types.NVarChar, discriminator);
+    removeItemRequest.input('indexInQueue', Types.Int, foundItemIndex);
+
+    await removeItemRequest.query(`
+      DELETE
+        FROM [${this.tableNames.items}]
+        WHERE [discriminator] = @discriminator
+          AND [indexInQueue] = @indexInQueue;
+      UPDATE [${this.tableNames.items}]
+        SET [indexInQueue] = [indexInQueue] - 1
+        WHERE [discriminator] = @discriminator
+          AND [indexInQueue] > @indexInQueue;
+    `);
+  }
+
+  public async remove ({ discriminator, itemIdentifier }: { discriminator: string; itemIdentifier: TItemIdentifier }): Promise<void> {
+    await this.functionCallQueue.add(
+      async (): Promise<void> => {
+        const transaction = this.pool.transaction();
+
+        await transaction.begin();
+
+        try {
+          await this.removeInternal({ transaction, discriminator, itemIdentifier });
           await transaction.commit();
         } catch (ex) {
           await transaction.rollback();

--- a/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/createPriorityQueueStore.ts
@@ -1,3 +1,4 @@
+import { DoesIdentifierMatchItem } from './DoesIdentifierMatchItem';
 import { errors } from '../../common/errors';
 import { InMemoryPriorityQueueStore } from './InMemory';
 import { MongoDbPriorityQueueStore } from './MongoDb';
@@ -5,25 +6,26 @@ import { MySqlPriorityQueueStore } from './MySql';
 import { PostgresPriorityQueueStore } from './Postgres';
 import { PriorityQueueStore } from './PriorityQueueStore';
 
-const createPriorityQueueStore = async function<TItem> ({ type, options }: {
+const createPriorityQueueStore = async function<TItem, TItemIdentifier> ({ type, doesIdentifierMatchItem, options }: {
   type: string;
+  doesIdentifierMatchItem: DoesIdentifierMatchItem<TItem, TItemIdentifier>;
   options: any;
-}): Promise<PriorityQueueStore<TItem>> {
+}): Promise<PriorityQueueStore<TItem, TItemIdentifier>> {
   switch (type) {
     case 'InMemory': {
-      return await InMemoryPriorityQueueStore.create(options);
+      return await InMemoryPriorityQueueStore.create<TItem, TItemIdentifier>({ doesIdentifierMatchItem, options });
     }
     case 'MariaDb': {
-      return await MySqlPriorityQueueStore.create(options);
+      return await MySqlPriorityQueueStore.create<TItem, TItemIdentifier>({ doesIdentifierMatchItem, options });
     }
     case 'MongoDb': {
-      return await MongoDbPriorityQueueStore.create(options);
+      return await MongoDbPriorityQueueStore.create<TItem, TItemIdentifier>({ doesIdentifierMatchItem, options });
     }
     case 'MySql': {
-      return await MySqlPriorityQueueStore.create(options);
+      return await MySqlPriorityQueueStore.create<TItem, TItemIdentifier>({ doesIdentifierMatchItem, options });
     }
     case 'Postgres': {
-      return await PostgresPriorityQueueStore.create(options);
+      return await PostgresPriorityQueueStore.create<TItem, TItemIdentifier>({ doesIdentifierMatchItem, options });
     }
     default: {
       throw new errors.DatabaseTypeInvalid();

--- a/test/integration/stores/priorityQueueStore/InMemoryTests.ts
+++ b/test/integration/stores/priorityQueueStore/InMemoryTests.ts
@@ -1,13 +1,17 @@
 import { getTestsFor } from './getTestsFor';
 import { InMemoryPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/InMemory';
+import { isEqual } from 'lodash';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 
 suite('InMemory', (): void => {
   getTestsFor({
     async createPriorityQueueStore ({ expirationTime }: {
       expirationTime: number;
-    }): Promise<PriorityQueueStore<any>> {
-      return await InMemoryPriorityQueueStore.create({ expirationTime });
+    }): Promise<PriorityQueueStore<any, any>> {
+      return await InMemoryPriorityQueueStore.create({
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: { expirationTime }
+      });
     }
   });
 });

--- a/test/integration/stores/priorityQueueStore/MariaDbTests.ts
+++ b/test/integration/stores/priorityQueueStore/MariaDbTests.ts
@@ -1,7 +1,6 @@
-import { CommandData } from '../../../../lib/common/elements/CommandData';
-import { CommandWithMetadata } from '../../../../lib/common/elements/CommandWithMetadata';
 import { connectionOptions } from '../../../shared/containers/connectionOptions';
 import { getTestsFor } from './getTestsFor';
+import { isEqual } from 'lodash';
 import { MySqlPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/MySql';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 
@@ -10,14 +9,17 @@ suite('MariaDb', (): void => {
     async createPriorityQueueStore ({ suffix, expirationTime }: {
       suffix: string;
       expirationTime: number;
-    }): Promise<PriorityQueueStore<CommandWithMetadata<CommandData>>> {
+    }): Promise<PriorityQueueStore<any, any>> {
       return await MySqlPriorityQueueStore.create({
-        ...connectionOptions.mariaDb,
-        tableNames: {
-          items: `items_${suffix}`,
-          priorityQueue: `priorityQueue_${suffix}`
-        },
-        expirationTime
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: {
+          ...connectionOptions.mariaDb,
+          tableNames: {
+            items: `items_${suffix}`,
+            priorityQueue: `priorityQueue_${suffix}`
+          },
+          expirationTime
+        }
       });
     }
   });

--- a/test/integration/stores/priorityQueueStore/MongoDbTests.ts
+++ b/test/integration/stores/priorityQueueStore/MongoDbTests.ts
@@ -1,5 +1,6 @@
 import { connectionOptions } from '../../../shared/containers/connectionOptions';
 import { getTestsFor } from './getTestsFor';
+import { isEqual } from 'lodash';
 import { MongoDbPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/MongoDb';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 
@@ -8,15 +9,18 @@ suite('MongoDb', (): void => {
     async createPriorityQueueStore ({ suffix, expirationTime }: {
       suffix: string;
       expirationTime: number;
-    }): Promise<PriorityQueueStore<any>> {
+    }): Promise<PriorityQueueStore<any, any>> {
       const collectionNames = {
         queues: `queues_${suffix}`
       };
 
       return await MongoDbPriorityQueueStore.create({
-        ...connectionOptions.mongoDb,
-        collectionNames,
-        expirationTime
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: {
+          ...connectionOptions.mongoDb,
+          collectionNames,
+          expirationTime
+        }
       });
     }
   });

--- a/test/integration/stores/priorityQueueStore/MySqlTests.ts
+++ b/test/integration/stores/priorityQueueStore/MySqlTests.ts
@@ -1,5 +1,6 @@
 import { connectionOptions } from '../../../shared/containers/connectionOptions';
 import { getTestsFor } from './getTestsFor';
+import { isEqual } from 'lodash';
 import { MySqlPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/MySql';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 
@@ -8,16 +9,19 @@ suite('MySql', (): void => {
     async createPriorityQueueStore ({ suffix, expirationTime }: {
       suffix: string;
       expirationTime: number;
-    }): Promise<PriorityQueueStore<any>> {
+    }): Promise<PriorityQueueStore<any, any>> {
       const tableNames = {
         items: `items_${suffix}`,
         priorityQueue: `priorityQueue_${suffix}`
       };
 
       return await MySqlPriorityQueueStore.create({
-        ...connectionOptions.mySql,
-        tableNames,
-        expirationTime
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: {
+          ...connectionOptions.mySql,
+          tableNames,
+          expirationTime
+        }
       });
     }
   });

--- a/test/integration/stores/priorityQueueStore/PostgresTests.ts
+++ b/test/integration/stores/priorityQueueStore/PostgresTests.ts
@@ -1,8 +1,8 @@
 import { connectionOptions } from '../../../shared/containers/connectionOptions';
 import { getTestsFor } from './getTestsFor';
+import { isEqual } from 'lodash';
 import { PostgresPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/Postgres';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
-import { isEqual } from 'lodash';
 
 suite('Postgres', (): void => {
   getTestsFor({

--- a/test/integration/stores/priorityQueueStore/PostgresTests.ts
+++ b/test/integration/stores/priorityQueueStore/PostgresTests.ts
@@ -2,22 +2,26 @@ import { connectionOptions } from '../../../shared/containers/connectionOptions'
 import { getTestsFor } from './getTestsFor';
 import { PostgresPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/Postgres';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
+import { isEqual } from 'lodash';
 
 suite('Postgres', (): void => {
   getTestsFor({
     async createPriorityQueueStore ({ suffix, expirationTime }: {
       suffix: string;
       expirationTime: number;
-    }): Promise<PriorityQueueStore<any>> {
+    }): Promise<PriorityQueueStore<any, any>> {
       const tableNames = {
         items: `items_${suffix}`,
         priorityQueue: `priorityQueue_${suffix}`
       };
 
       return await PostgresPriorityQueueStore.create({
-        ...connectionOptions.postgres,
-        tableNames,
-        expirationTime
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: {
+          ...connectionOptions.postgres,
+          tableNames,
+          expirationTime
+        }
       });
     }
   });

--- a/test/integration/stores/priorityQueueStore/SqlServerTests.ts
+++ b/test/integration/stores/priorityQueueStore/SqlServerTests.ts
@@ -1,5 +1,6 @@
 import { connectionOptions } from '../../../shared/containers/connectionOptions';
 import { getTestsFor } from './getTestsFor';
+import { isEqual } from 'lodash';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 import { SqlServerPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/SqlServer';
 
@@ -8,16 +9,19 @@ suite('SqlServer', (): void => {
     async createPriorityQueueStore ({ suffix, expirationTime }: {
       suffix: string;
       expirationTime: number;
-    }): Promise<PriorityQueueStore<any>> {
+    }): Promise<PriorityQueueStore<any, any>> {
       const tableNames = {
         items: `items_${suffix}`,
         priorityQueue: `priorityQueue_${suffix}`
       };
 
       return await SqlServerPriorityQueueStore.create({
-        ...connectionOptions.sqlServer,
-        tableNames,
-        expirationTime
+        doesIdentifierMatchItem: ({ item, itemIdentifier }): boolean => isEqual(item, itemIdentifier),
+        options: {
+          ...connectionOptions.sqlServer,
+          tableNames,
+          expirationTime
+        }
       });
     }
   });

--- a/test/runtime/microservice/processes/command/processTests.ts
+++ b/test/runtime/microservice/processes/command/processTests.ts
@@ -88,7 +88,7 @@ suite('command', (): void => {
     });
 
     suite('postCommand', (): void => {
-      test('sends commands to the right endpoint at the dispatcher.', async (): Promise<void> => {
+      test('sends commands to the correct endpoint at the dispatcher.', async (): Promise<void> => {
         const command = new Command({
           contextIdentifier: { name: 'sampleContext' },
           aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
@@ -150,7 +150,7 @@ suite('command', (): void => {
     });
 
     suite('cancelCommand', (): void => {
-      test('sends a cancel request to the right endpoint at the dispatcher.', async (): Promise<void> => {
+      test('sends a cancel request to the correct endpoint at the dispatcher.', async (): Promise<void> => {
         const commandIdentifier: ItemIdentifier = {
           contextIdentifier: { name: 'sampleContext' },
           aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },

--- a/test/runtime/microservice/processes/command/processTests.ts
+++ b/test/runtime/microservice/processes/command/processTests.ts
@@ -154,14 +154,14 @@ suite('command', (): void => {
         const commandIdentifier: ItemIdentifier = {
           contextIdentifier: { name: 'sampleContext' },
           aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
-          name: 'excute',
+          name: 'execute',
           id: uuid()
         };
 
         await handleCommandClient.cancelCommand({ commandIdentifier });
 
         assert.that(endpointCommandWasSentTo).is.equalTo('/handle-command/v2/cancel');
-        assert.that(commandReceivedByDispatcher).is.equalTo(commandIdentifier);
+        assert.that(commandReceivedByDispatcher).is.atLeast(commandIdentifier);
       });
 
       test('fails if sending the cancel request to the dispatcher fails.', async (): Promise<void> => {
@@ -189,7 +189,7 @@ suite('command', (): void => {
         const commandIdentifier: ItemIdentifier = {
           contextIdentifier: { name: 'sampleContext' },
           aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
-          name: 'excute',
+          name: 'execute',
           id: uuid()
         };
 

--- a/test/unit/apis/awaitCommandWithMetadata/ClientTests.ts
+++ b/test/unit/apis/awaitCommandWithMetadata/ClientTests.ts
@@ -5,14 +5,16 @@ import { buildCommandWithMetadata } from '../../../../lib/common/utils/test/buil
 import { Client } from '../../../../lib/apis/awaitCommandWithMetadata/http/v2/Client';
 import { CommandData } from '../../../../lib/common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../lib/common/elements/CommandWithMetadata';
+import { createPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/createPriorityQueueStore';
 import { CustomError } from 'defekt';
+import { doesItemIdentifierWithClientMatchCommandWithMetadata } from '../../../../lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata';
 import { getApi } from '../../../../lib/apis/awaitCommandWithMetadata/http';
 import { getApplicationDefinition } from '../../../../lib/common/application/getApplicationDefinition';
 import { getPromiseStatus } from '../../../../lib/common/utils/getPromiseStatus';
 import { getTestApplicationDirectory } from '../../../shared/applications/getTestApplicationDirectory';
-import { InMemoryPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/InMemory';
 import { InMemoryPublisher } from '../../../../lib/messaging/pubSub/InMemory/InMemoryPublisher';
 import { InMemorySubscriber } from '../../../../lib/messaging/pubSub/InMemory/InMemorySubscriber';
+import { ItemIdentifierWithClient } from '../../../../lib/common/elements/ItemIdentifierWithClient';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 import { Publisher } from '../../../../lib/messaging/pubSub/Publisher';
 import { runAsServer } from '../../../shared/http/runAsServer';
@@ -30,7 +32,7 @@ suite('awaitCommandWithMetadata/http/Client', (): void => {
         newCommandPublisher: Publisher<object>,
         newCommandSubscriber: Subscriber<object>,
         newCommandSubscriberChannel: string,
-        priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+        priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
 
     setup(async (): Promise<void> => {
       const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
@@ -41,8 +43,10 @@ suite('awaitCommandWithMetadata/http/Client', (): void => {
       newCommandSubscriberChannel = uuid();
       newCommandPublisher = await InMemoryPublisher.create();
 
-      priorityQueueStore = await InMemoryPriorityQueueStore.create({
-        expirationTime
+      priorityQueueStore = await createPriorityQueueStore({
+        type: 'InMemory',
+        doesIdentifierMatchItem: doesItemIdentifierWithClientMatchCommandWithMetadata,
+        options: { expirationTime }
       });
 
       ({ api } = await getApi({

--- a/test/unit/apis/awaitCommandWithMetadata/httpTests.ts
+++ b/test/unit/apis/awaitCommandWithMetadata/httpTests.ts
@@ -5,12 +5,14 @@ import { assert } from 'assertthat';
 import { buildCommandWithMetadata } from '../../../../lib/common/utils/test/buildCommandWithMetadata';
 import { CommandData } from '../../../../lib/common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../lib/common/elements/CommandWithMetadata';
+import { createPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/createPriorityQueueStore';
+import { doesItemIdentifierWithClientMatchCommandWithMetadata } from '../../../../lib/common/domain/doesItemIdentifierWithClientMatchCommandWithMetadata';
 import { getApi } from '../../../../lib/apis/awaitCommandWithMetadata/http';
 import { getApplicationDefinition } from '../../../../lib/common/application/getApplicationDefinition';
 import { getTestApplicationDirectory } from '../../../shared/applications/getTestApplicationDirectory';
-import { InMemoryPriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/InMemory';
 import { InMemoryPublisher } from '../../../../lib/messaging/pubSub/InMemory/InMemoryPublisher';
 import { InMemorySubscriber } from '../../../../lib/messaging/pubSub/InMemory/InMemorySubscriber';
+import { ItemIdentifierWithClient } from '../../../../lib/common/elements/ItemIdentifierWithClient';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 import { Publisher } from '../../../../lib/messaging/pubSub/Publisher';
 import { runAsServer } from '../../../shared/http/runAsServer';
@@ -28,7 +30,7 @@ suite('awaitCommandWithMetadata/http', (): void => {
         newCommandPublisher: Publisher<object>,
         newCommandSubscriber: Subscriber<object>,
         newCommandSubscriberChannel: string,
-        priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>>;
+        priorityQueueStore: PriorityQueueStore<CommandWithMetadata<CommandData>, ItemIdentifierWithClient>;
 
     setup(async (): Promise<void> => {
       const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
@@ -39,8 +41,10 @@ suite('awaitCommandWithMetadata/http', (): void => {
       newCommandSubscriberChannel = uuid();
       newCommandPublisher = await InMemoryPublisher.create();
 
-      priorityQueueStore = await InMemoryPriorityQueueStore.create({
-        expirationTime
+      priorityQueueStore = await createPriorityQueueStore({
+        type: 'InMemory',
+        doesIdentifierMatchItem: doesItemIdentifierWithClientMatchCommandWithMetadata,
+        options: { expirationTime }
       });
 
       ({ api } = await getApi({

--- a/test/unit/apis/handleCommand/ClientTests.ts
+++ b/test/unit/apis/handleCommand/ClientTests.ts
@@ -11,10 +11,10 @@ import { getApplicationDefinition } from '../../../../lib/common/application/get
 import { getApplicationDescription } from '../../../../lib/common/application/getApplicationDescription';
 import { getTestApplicationDirectory } from '../../../shared/applications/getTestApplicationDirectory';
 import { identityProvider } from '../../../shared/identityProvider';
+import { ItemIdentifier } from '../../../../lib/common/elements/ItemIdentifier';
 import { ItemIdentifierWithClient } from '../../../../lib/common/elements/ItemIdentifierWithClient';
 import { runAsServer } from '../../../shared/http/runAsServer';
 import { uuid } from 'uuidv4';
-import { ItemIdentifier } from '../../../../lib/common/elements/ItemIdentifier';
 
 suite('handleCommand/http/Client', (): void => {
   const identityProviders = [ identityProvider ];

--- a/test/unit/apis/handleCommand/ClientTests.ts
+++ b/test/unit/apis/handleCommand/ClientTests.ts
@@ -11,8 +11,10 @@ import { getApplicationDefinition } from '../../../../lib/common/application/get
 import { getApplicationDescription } from '../../../../lib/common/application/getApplicationDescription';
 import { getTestApplicationDirectory } from '../../../shared/applications/getTestApplicationDirectory';
 import { identityProvider } from '../../../shared/identityProvider';
+import { ItemIdentifierWithClient } from '../../../../lib/common/elements/ItemIdentifierWithClient';
 import { runAsServer } from '../../../shared/http/runAsServer';
 import { uuid } from 'uuidv4';
+import { ItemIdentifier } from '../../../../lib/common/elements/ItemIdentifier';
 
 suite('handleCommand/http/Client', (): void => {
   const identityProviders = [ identityProvider ];
@@ -33,7 +35,10 @@ suite('handleCommand/http/Client', (): void => {
         ({ api } = await getApi({
           corsOrigin: '*',
           async onReceiveCommand (): Promise<void> {
-          // Intentionally left blank.
+            // Intentionally left blank.
+          },
+          async onCancelCommand (): Promise<void> {
+            // Intentionally left blank.
           },
           applicationDefinition,
           identityProviders
@@ -77,6 +82,9 @@ suite('handleCommand/http/Client', (): void => {
             command: CommandWithMetadata<CommandData>;
           }): Promise<void> {
             receivedCommands.push(command);
+          },
+          async onCancelCommand (): Promise<void> {
+            // Intentionally left blank.
           },
           applicationDefinition,
           identityProviders
@@ -238,6 +246,9 @@ suite('handleCommand/http/Client', (): void => {
           async onReceiveCommand (): Promise<void> {
             throw new Error('Failed to handle received command.');
           },
+          async onCancelCommand (): Promise<void> {
+            // Intentionally left blank.
+          },
           applicationDefinition,
           identityProviders
         }));
@@ -261,6 +272,152 @@ suite('handleCommand/http/Client', (): void => {
         }).is.throwingAsync((ex): boolean =>
           (ex as CustomError).code === 'EUNKNOWNERROR' &&
           (ex as CustomError).message === 'Unknown error.');
+      });
+    });
+
+    suite('cancelCommand', (): void => {
+      let api: Application,
+          cancelledCommands: ItemIdentifierWithClient[];
+
+      setup(async (): Promise<void> => {
+        cancelledCommands = [];
+
+        ({ api } = await getApi({
+          corsOrigin: '*',
+          async onReceiveCommand (): Promise<void> {
+            // Intentionally left blank.
+          },
+          async onCancelCommand ({ commandIdentifierWithClient }: {
+            commandIdentifierWithClient: ItemIdentifierWithClient;
+          }): Promise<void> {
+            cancelledCommands.push(commandIdentifierWithClient);
+          },
+          applicationDefinition,
+          identityProviders
+        }));
+      });
+
+      test('throws an exception if a non-existent context name is given.', async (): Promise<void> => {
+        const commandIdentifier: ItemIdentifier = {
+          contextIdentifier: { name: 'nonExistent' },
+          aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
+          name: 'execute',
+          id: uuid()
+        };
+
+        const { port } = await runAsServer({ app: api });
+        const client = new Client({
+          hostName: 'localhost',
+          port,
+          path: '/v2'
+        });
+
+        await assert.that(async (): Promise<void> => {
+          await client.cancelCommand({ commandIdentifier });
+        }).is.throwingAsync((ex): boolean => (ex as CustomError).code === 'ECONTEXTNOTFOUND');
+      });
+
+      test('throws an exception if a non-existent aggregate name is given.', async (): Promise<void> => {
+        const commandIdentifier: ItemIdentifier = {
+          contextIdentifier: { name: 'sampleContext' },
+          aggregateIdentifier: { name: 'nonExistent', id: uuid() },
+          name: 'execute',
+          id: uuid()
+        };
+
+        const { port } = await runAsServer({ app: api });
+        const client = new Client({
+          hostName: 'localhost',
+          port,
+          path: '/v2'
+        });
+
+        await assert.that(async (): Promise<void> => {
+          await client.cancelCommand({ commandIdentifier });
+        }).is.throwingAsync((ex): boolean => (ex as CustomError).code === 'EAGGREGATENOTFOUND');
+      });
+
+      test('throws an exception if a non-existent command name is given.', async (): Promise<void> => {
+        const commandIdentifier: ItemIdentifier = {
+          contextIdentifier: { name: 'sampleContext' },
+          aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
+          name: 'nonExistent',
+          id: uuid()
+        };
+
+        const { port } = await runAsServer({ app: api });
+        const client = new Client({
+          hostName: 'localhost',
+          port,
+          path: '/v2'
+        });
+
+        await assert.that(async (): Promise<void> => {
+          await client.cancelCommand({ commandIdentifier });
+        }).is.throwingAsync((ex): boolean => (ex as CustomError).code === 'ECOMMANDNOTFOUND');
+      });
+
+      test('cancels commands.', async (): Promise<void> => {
+        const commandIdentifier: ItemIdentifier = {
+          contextIdentifier: { name: 'sampleContext' },
+          aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
+          name: 'execute',
+          id: uuid()
+        };
+
+        const { port } = await runAsServer({ app: api });
+        const client = new Client({
+          hostName: 'localhost',
+          port,
+          path: '/v2'
+        });
+
+        await client.cancelCommand({ commandIdentifier });
+
+        assert.that(cancelledCommands.length).is.equalTo(1);
+        assert.that(cancelledCommands[0]).is.atLeast({
+          contextIdentifier: commandIdentifier.contextIdentifier,
+          aggregateIdentifier: commandIdentifier.aggregateIdentifier,
+          name: commandIdentifier.name,
+          id: commandIdentifier.id,
+          client: {
+            user: { id: 'anonymous', claims: { sub: 'anonymous', iss: 'https://token.invalid' }}
+          }
+        });
+      });
+
+      test('throws an error if on received command throws an error.', async (): Promise<void> => {
+        ({ api } = await getApi({
+          corsOrigin: '*',
+          async onReceiveCommand (): Promise<void> {
+            // Intentionally left blank.
+          },
+          async onCancelCommand (): Promise<void> {
+            throw new Error('Failed to cancel command.');
+          },
+          applicationDefinition,
+          identityProviders
+        }));
+
+        const commandIdentifier: ItemIdentifier = {
+          contextIdentifier: { name: 'sampleContext' },
+          aggregateIdentifier: { name: 'sampleAggregate', id: uuid() },
+          name: 'execute',
+          id: uuid()
+        };
+
+        const { port } = await runAsServer({ app: api });
+        const client = new Client({
+          hostName: 'localhost',
+          port,
+          path: '/v2'
+        });
+
+        await assert.that(async (): Promise<void> => {
+          await client.cancelCommand({ commandIdentifier });
+        }).is.throwingAsync((ex): boolean =>
+          (ex as CustomError).code === 'EUNKNOWNERROR' &&
+            (ex as CustomError).message === 'Unknown error.');
       });
     });
   });

--- a/test/unit/common/validators/validateItemIdentifierTests.ts
+++ b/test/unit/common/validators/validateItemIdentifierTests.ts
@@ -64,4 +64,38 @@ suite('validateItemIdentifier', (): void => {
         ex.message === `Aggregate 'sampleContext.someAggregate' not found.`
     );
   });
+
+  test(`throws an error if the command identifier's name doesn't exist in the application definition.`, async (): Promise<void> => {
+    assert.that((): void => {
+      validateItemIdentifier({
+        itemIdentifier: {
+          ...itemIdentifier,
+          name: 'nonExistent'
+        },
+        applicationDefinition,
+        itemType: 'command'
+      });
+    }).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'ECOMMANDNOTFOUND' &&
+        ex.message === `Command 'sampleContext.sampleAggregate.nonExistent' not found.`
+    );
+  });
+
+  test(`throws an error if the domain event identifier's name doesn't exist in the application definition.`, async (): Promise<void> => {
+    assert.that((): void => {
+      validateItemIdentifier({
+        itemIdentifier: {
+          ...itemIdentifier,
+          name: 'nonExistent'
+        },
+        applicationDefinition,
+        itemType: 'domain-event'
+      });
+    }).is.throwing(
+      (ex): boolean =>
+        (ex as CustomError).code === 'EDOMAINEVENTNOTFOUND' &&
+        ex.message === `Domain event 'sampleContext.sampleAggregate.nonExistent' not found.`
+    );
+  });
 });


### PR DESCRIPTION
- Fix bug in SQL-based PriorityQueueStore implementations where
  acknowledging the last command in a queue would cause an error
- Implement new http routes on handleCommand and
  handleCommandWithMetadata apis to cancel unprocessed commands
- Implement new method remove on PriorityQueueStores that removes
  an unlocked item from the priority queue

Closes #889.