### PR TITLE
feat: Implement domain event dispatcher.

### DIFF
--- a/lib/apis/awaitItem/http/v2/Client.ts
+++ b/lib/apis/awaitItem/http/v2/Client.ts
@@ -4,6 +4,7 @@ import { FilterHeartbeatsFromJsonStreamTransform } from '../../../../common/util
 import { flaschenpost } from 'flaschenpost';
 import { HttpClient } from '../../../shared/HttpClient';
 import { ItemIdentifier } from '../../../../common/elements/ItemIdentifier';
+import { LockMetadata } from '../../../../stores/priorityQueueStore/LockMetadata';
 import { PassThrough, pipeline } from 'stream';
 
 const logger = flaschenpost.getLogger();
@@ -29,7 +30,7 @@ class Client<TItem, TItemIdentifier extends ItemIdentifier> extends HttpClient {
     this.createItemInstance = createItemInstance;
   }
 
-  public async awaitItem (): Promise<{ item: TItem; token: string }> {
+  public async awaitItem (): Promise<{ item: TItem; metadata: LockMetadata }> {
     const { data } = await axios({
       method: 'get',
       url: this.url,
@@ -39,7 +40,7 @@ class Client<TItem, TItemIdentifier extends ItemIdentifier> extends HttpClient {
     const passThrough = new PassThrough({ objectMode: true });
     const heartbeatFilter = new FilterHeartbeatsFromJsonStreamTransform();
 
-    const { item, token } = await new Promise((resolve, reject): void => {
+    const { item, metadata } = await new Promise((resolve, reject): void => {
       let unsubscribe: () => void;
 
       const onData = (nextItem: any): void => {
@@ -73,7 +74,7 @@ class Client<TItem, TItemIdentifier extends ItemIdentifier> extends HttpClient {
 
     return {
       item: this.createItemInstance({ item }),
-      token
+      metadata
     };
   }
 

--- a/lib/apis/awaitItem/http/v2/awaitItem.ts
+++ b/lib/apis/awaitItem/http/v2/awaitItem.ts
@@ -23,9 +23,17 @@ const awaitItem = {
       type: 'object',
       properties: {
         item: {},
-        token: jsonSchema.v4
+        metadata: {
+          type: 'object',
+          properties: {
+            discriminator: { type: 'string', minLength: 1 },
+            token: jsonSchema.v4
+          },
+          required: [ 'discriminator', 'token' ],
+          additionalProperties: false
+        }
       },
-      required: [ 'item', 'token' ],
+      required: [ 'item', 'metadata' ],
       additionalProperties: false
     }
   },

--- a/lib/common/domain/doesItemIdentifierWithClientMatchDomainEvent.ts
+++ b/lib/common/domain/doesItemIdentifierWithClientMatchDomainEvent.ts
@@ -1,0 +1,16 @@
+import { DoesIdentifierMatchItem } from '../../stores/priorityQueueStore/DoesIdentifierMatchItem';
+import { DomainEvent } from '../elements/DomainEvent';
+import { DomainEventData } from '../elements/DomainEventData';
+import { isEqual } from 'lodash';
+import { ItemIdentifierWithClient } from '../elements/ItemIdentifierWithClient';
+
+const doesItemIdentifierWithClientMatchDomainEvent: DoesIdentifierMatchItem<DomainEvent<DomainEventData>, ItemIdentifierWithClient> =
+    function ({ item, itemIdentifier }): boolean {
+      return isEqual(item.contextIdentifier, itemIdentifier.contextIdentifier) &&
+        isEqual(item.aggregateIdentifier, itemIdentifier.aggregateIdentifier) &&
+        item.name === itemIdentifier.name &&
+        item.id === itemIdentifier.id &&
+        isEqual(item.metadata.initiator.user, itemIdentifier.client.user);
+    };
+
+export { doesItemIdentifierWithClientMatchDomainEvent };

--- a/lib/runtimes/microservice/processes/domain/Configuration.ts
+++ b/lib/runtimes/microservice/processes/domain/Configuration.ts
@@ -11,6 +11,7 @@ export interface Configuration {
   publisherHostName: string;
   publisherPort: number;
   publisherChannelNewDomainEvent: string;
+  publisherChannelNewDomainEventInternal: string;
   aeonstoreProtocol: string;
   aeonstoreHostName: string;
   aeonstorePort: number;

--- a/lib/runtimes/microservice/processes/domain/app.ts
+++ b/lib/runtimes/microservice/processes/domain/app.ts
@@ -74,6 +74,10 @@ import { State } from '../../../../common/elements/State';
           channel: configuration.publisherChannelNewDomainEvent,
           message: domainEvent
         });
+        await publisherClient.postMessage({
+          channel: configuration.publisherChannelNewDomainEventInternal,
+          message: domainEvent
+        });
       }
     };
 

--- a/lib/runtimes/microservice/processes/domain/fetchCommand.ts
+++ b/lib/runtimes/microservice/processes/domain/fetchCommand.ts
@@ -1,6 +1,7 @@
 import { CommandData } from '../../../../common/elements/CommandData';
 import { CommandDispatcher } from './CommandDispatcher';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { LockMetadata } from '../../../../stores/priorityQueueStore/LockMetadata';
 import { retry } from 'retry-ignore-abort';
 
 const fetchCommand = async function ({ commandDispatcher }: {
@@ -9,15 +10,15 @@ const fetchCommand = async function ({ commandDispatcher }: {
     command: CommandWithMetadata<CommandData>;
     token: string;
   }> {
-  const { item, token } = await retry(
+  const { item, metadata } = await retry(
     async (): Promise<{
       item: CommandWithMetadata<CommandData>;
-      token: string;
+      metadata: LockMetadata;
     }> => await commandDispatcher.client.awaitItem(),
     { retries: Number.POSITIVE_INFINITY, maxTimeout: 1000 }
   );
 
-  return { command: item, token };
+  return { command: item, token: metadata.token };
 };
 
 export {

--- a/lib/runtimes/microservice/processes/domain/getConfiguration.ts
+++ b/lib/runtimes/microservice/processes/domain/getConfiguration.ts
@@ -61,6 +61,10 @@ const getConfiguration = function (): Configuration {
       default: 'newDomainEvent',
       schema: { type: 'string', minLength: 1 }
     },
+    PUBLISHER_CHANNEL_NEW_DOMAIN_EVENT_INTERNAL: {
+      default: 'newDomainEventInternal',
+      schema: { type: 'string' }
+    },
     AEONSTORE_PROTOCOL: {
       default: 'http',
       schema: protocolSchema

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/Configuration.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/Configuration.ts
@@ -1,0 +1,21 @@
+export interface Configuration {
+  applicationDirectory: string;
+  priorityQueueStoreType: string;
+  priorityQueueStoreOptions: object & { expirationTime: number };
+  pubSubType: string;
+  pubSubOptions: {
+    channel: string;
+    subscriber: object;
+    publisher: object;
+  };
+  subscribeMessagesProtocol: string;
+  subscribeMessagesHostName: string;
+  subscribeMessagesPort: number;
+  subscribeMessagesChannel: string;
+  awaitCommandCorsOrigin: string | string[];
+  handleCommandCorsOrigin: string | string[];
+  healthCorsOrigin: string | string[];
+  port: number;
+  healthPort: number;
+  missedCommandRecoveryInterval: number;
+}

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
@@ -106,11 +106,13 @@ import { Value } from 'validate-value';
         return;
       }
 
-      await priorityQueueStore.enqueue({
-        item: domainEvent,
-        discriminator: domainEvent.aggregateIdentifier.id,
-        priority: domainEvent.metadata.timestamp
-      });
+      for (const flowName of Object.keys(application.flows)) {
+        await priorityQueueStore.enqueue({
+          item: domainEvent,
+          discriminator: flowName,
+          priority: domainEvent.metadata.timestamp
+        });
+      }
       await internalNewDomainEventPublisher.publish({
         channel: configuration.pubSubOptions.channel,
         message: {}

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { createPriorityQueueStore } from '../../../../stores/priorityQueueStore/createPriorityQueueStore';
+import { createPublisher } from '../../../../messaging/pubSub/createPublisher';
+import { createSubscriber } from '../../../../messaging/pubSub/createSubscriber';
+import { doesItemIdentifierWithClientMatchDomainEvent } from '../../../../common/domain/doesItemIdentifierWithClientMatchDomainEvent';
+import { DomainEvent } from '../../../../common/elements/DomainEvent';
+import { DomainEventData } from '../../../../common/elements/DomainEventData';
+import { flaschenpost } from 'flaschenpost';
+import { getApi } from './getApi';
+import { getConfiguration } from './getConfiguration';
+import { getDomainEventSchema } from '../../../../common/schemas/getDomainEventSchema';
+import http from 'http';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { loadApplication } from '../../../../common/application/loadApplication';
+import { registerExceptionHandler } from '../../../../common/utils/process/registerExceptionHandler';
+import { runHealthServer } from '../../../shared/runHealthServer';
+import { Client as SubscribeMessagesClient } from '../../../../apis/subscribeMessages/http/v2/Client';
+import { validateDomainEvent } from '../../../../common/validators/validateDomainEvent';
+import { Value } from 'validate-value';
+
+/* eslint-disable @typescript-eslint/no-floating-promises */
+(async (): Promise<void> => {
+  const logger = flaschenpost.getLogger();
+
+  try {
+    registerExceptionHandler();
+
+    const configuration = getConfiguration();
+
+    const application = await loadApplication({
+      applicationDirectory: configuration.applicationDirectory
+    });
+
+    const priorityQueueStore = await createPriorityQueueStore<DomainEvent<DomainEventData>, ItemIdentifierWithClient>({
+      type: configuration.priorityQueueStoreType,
+      doesIdentifierMatchItem: doesItemIdentifierWithClientMatchDomainEvent,
+      options: {
+        ...configuration.priorityQueueStoreOptions,
+        expirationTime: configuration.priorityQueueStoreOptions.expirationTime
+      }
+    });
+
+    const internalNewDomainEventSubscriber = await createSubscriber<object>({
+      type: configuration.pubSubType,
+      options: configuration.pubSubOptions.subscriber
+    });
+
+    const internalNewDomainEventPublisher = await createPublisher<object>({
+      type: configuration.pubSubType,
+      options: configuration.pubSubOptions.publisher
+    });
+
+    // Publish new command events on an interval even if there are no new
+    // commands so that missed events or crashing workers will not lead to
+    // unprocessed commands.
+    setInterval(
+      async (): Promise<void> => {
+        await internalNewDomainEventPublisher.publish({
+          channel: configuration.pubSubOptions.channel,
+          message: {}
+        });
+      },
+      configuration.missedCommandRecoveryInterval
+    );
+
+    const { api } = await getApi({
+      configuration,
+      application,
+      priorityQueueStore,
+      newDomainEventSubscriber: internalNewDomainEventSubscriber,
+      newDomainEventPubSubChannel: configuration.pubSubOptions.channel
+    });
+
+    await runHealthServer({ corsOrigin: configuration.healthCorsOrigin, port: configuration.healthPort });
+
+    const server = http.createServer(api);
+
+    server.listen(configuration.port, (): void => {
+      logger.info(
+        'CommandDispatcher server started.',
+        { port: configuration.port, healthPort: configuration.healthPort }
+      );
+    });
+
+    const externalNewDomainEventSubscriber = new SubscribeMessagesClient({
+      protocol: configuration.subscribeMessagesProtocol,
+      hostName: configuration.subscribeMessagesHostName,
+      port: configuration.subscribeMessagesPort,
+      path: '/subscribe/v2'
+    });
+
+    const domainEventStream = await externalNewDomainEventSubscriber.getMessages({
+      channel: configuration.subscribeMessagesChannel
+    });
+
+    for await (const rawDomainEvent of domainEventStream) {
+      const domainEvent = new DomainEvent<DomainEventData>(rawDomainEvent);
+
+      try {
+        new Value(getDomainEventSchema()).validate(domainEvent);
+        validateDomainEvent({ domainEvent, application });
+      } catch (ex) {
+        logger.error('Received a message via the publisher with an unexpected format.', { domainEvent, ex });
+
+        return;
+      }
+
+      await priorityQueueStore.enqueue({
+        item: domainEvent,
+        discriminator: domainEvent.aggregateIdentifier.id,
+        priority: domainEvent.metadata.timestamp
+      });
+      await internalNewDomainEventPublisher.publish({
+        channel: configuration.pubSubOptions.channel,
+        message: {}
+      });
+    }
+  } catch (ex) {
+    logger.fatal('An unexpected error occured.', { ex });
+    process.exit(1);
+  }
+})();
+/* eslint-enable @typescript-eslint/no-floating-promises */

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/app.ts
@@ -78,7 +78,7 @@ import { Value } from 'validate-value';
 
     server.listen(configuration.port, (): void => {
       logger.info(
-        'CommandDispatcher server started.',
+        'Domain event dispatcher server started.',
         { port: configuration.port, healthPort: configuration.healthPort }
       );
     });

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/getApi.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/getApi.ts
@@ -1,0 +1,50 @@
+import { Application } from '../../../../common/application/Application';
+import { Configuration } from './Configuration';
+import { DomainEvent } from '../../../../common/elements/DomainEvent';
+import { DomainEventData } from '../../../../common/elements/DomainEventData';
+import { getApi as getAwaitDomainEventApi } from '../../../../apis/awaitItem/http';
+import { getCorsOrigin } from 'get-cors-origin';
+import { getDomainEventSchema } from '../../../../common/schemas/getDomainEventSchema';
+import { ItemIdentifier } from '../../../../common/elements/ItemIdentifier';
+import { ItemIdentifierWithClient } from '../../../../common/elements/ItemIdentifierWithClient';
+import { PriorityQueueStore } from '../../../../stores/priorityQueueStore/PriorityQueueStore';
+import { Subscriber } from '../../../../messaging/pubSub/Subscriber';
+import { validateDomainEvent } from '../../../../common/validators/validateDomainEvent';
+import { Value } from 'validate-value';
+import express, { Application as ExpressApplication } from 'express';
+
+const getApi = async function ({
+  configuration,
+  application,
+  priorityQueueStore,
+  newDomainEventSubscriber,
+  newDomainEventPubSubChannel
+}: {
+  configuration: Configuration;
+  application: Application;
+  priorityQueueStore: PriorityQueueStore<DomainEvent<DomainEventData>, ItemIdentifierWithClient>;
+  newDomainEventSubscriber: Subscriber<object>;
+  newDomainEventPubSubChannel: string;
+}): Promise<{ api: ExpressApplication }> {
+  const { api: awaitDomainEventApi } = await getAwaitDomainEventApi<DomainEvent<DomainEventData>, ItemIdentifier>({
+    application,
+    corsOrigin: getCorsOrigin(configuration.awaitCommandCorsOrigin),
+    priorityQueueStore,
+    newItemSubscriber: newDomainEventSubscriber,
+    newItemSubscriberChannel: newDomainEventPubSubChannel,
+    validateOutgoingItem ({ item }: {
+      item: DomainEvent<DomainEventData>;
+    }): void {
+      new Value(getDomainEventSchema()).validate(item);
+      validateDomainEvent({ application, domainEvent: item });
+    }
+  });
+
+  const api = express();
+
+  api.use('/await-domain-event', awaitDomainEventApi);
+
+  return { api };
+};
+
+export { getApi };

--- a/lib/runtimes/microservice/processes/domainEventDispatcher/getConfiguration.ts
+++ b/lib/runtimes/microservice/processes/domainEventDispatcher/getConfiguration.ts
@@ -1,0 +1,101 @@
+import { Configuration } from './Configuration';
+import { getCorsSchema } from '../../../shared/schemas/getCorsSchema';
+import { getEnvironmentVariables } from '../../../../common/utils/process/getEnvironmentVariables';
+import { getPortSchema } from '../../../shared/schemas/getPortSchema';
+import { getProtocolSchema } from '../../../shared/schemas/getProtocolSchema';
+import path from 'path';
+import { withCamelCaseKeys } from '../../../../common/utils/withCamelCaseKeys';
+
+const corsSchema = getCorsSchema();
+const portSchema = getPortSchema();
+const protocolSchema = getProtocolSchema();
+
+const getConfiguration = function (): Configuration {
+  const environmentVariables = getEnvironmentVariables({
+    APPLICATION_DIRECTORY: {
+      default: path.join(__dirname, '..', '..', '..', '..', '..', 'test', 'shared', 'applications', 'javascript', 'base'),
+      schema: { type: 'string', minLength: 1 }
+    },
+    PRIORITY_QUEUE_STORE_TYPE: {
+      default: 'InMemory',
+      schema: { type: 'string', minLength: 1 }
+    },
+    PRIORITY_QUEUE_STORE_OPTIONS: {
+      default: { expirationTime: 30_000 },
+      schema: {
+        type: 'object',
+        properties: {
+          expirationTime: { type: 'number', minimum: 1 }
+        },
+        required: [ 'expirationTime' ],
+        additionalProperties: true
+      }
+    },
+    PUB_SUB_TYPE: {
+      default: 'InMemory',
+      schema: { type: 'string', minLength: 1 }
+    },
+    PUB_SUB_OPTIONS: {
+      default: { channel: 'newDomainEvent', subscriber: {}, publisher: {}},
+      schema: {
+        type: 'object',
+        properties: {
+          channel: { type: 'string', minLength: 1 },
+          subscriber: { type: 'object' },
+          publisher: { type: 'object' }
+        },
+        required: [ 'channel', 'subscriber', 'publisher' ],
+        additionalProperties: false
+      }
+    },
+    SUBSCRIBE_MESSAGES_PROTOCOL: {
+      default: 'http',
+      schema: protocolSchema
+    },
+    SUBSCRIBE_MESSAGES_HOST_NAME: {
+      default: 'publisher',
+      schema: {
+        type: 'string',
+        format: 'hostname'
+      }
+    },
+    SUBSCRIBE_MESSAGES_PORT: {
+      default: 3000,
+      schema: portSchema
+    },
+    SUBSCRIBE_MESSAGES_CHANNEL: {
+      default: 'newDomainEventInternal',
+      schema: { type: 'string' }
+    },
+    AWAIT_COMMAND_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    HANDLE_COMMAND_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    HEALTH_CORS_ORIGIN: {
+      default: '*',
+      schema: corsSchema
+    },
+    PORT: {
+      default: 3_000,
+      schema: portSchema
+    },
+    HEALTH_PORT: {
+      default: 3_001,
+      schema: portSchema
+    },
+    MISSED_COMMAND_RECOVERY_INTERVAL: {
+      default: 5_000,
+      schema: { type: 'number', minimum: 1 }
+    }
+  });
+
+  return withCamelCaseKeys(environmentVariables) as Configuration;
+};
+
+export {
+  getConfiguration
+};

--- a/lib/runtimes/singleProcess/processes/main/Configuration.ts
+++ b/lib/runtimes/singleProcess/processes/main/Configuration.ts
@@ -9,8 +9,10 @@ export interface Configuration {
   domainEventStoreType: string;
   lockStoreOptions: object;
   lockStoreType: string;
-  priorityQueueStoreType: string;
-  priorityQueueStoreOptions: object & { expirationTime: number };
+  priorityQueueStoreForCommandsType: string;
+  priorityQueueStoreForCommandsOptions: object & { expirationTime: number };
+  priorityQueueStoreForDomainEventsType: string;
+  priorityQueueStoreForDomainEventsOptions: object & { expirationTime: number };
   identityProviders: { issuer: string; certificate: string }[];
   port: number;
   healthPort: number;

--- a/lib/runtimes/singleProcess/processes/main/app.ts
+++ b/lib/runtimes/singleProcess/processes/main/app.ts
@@ -108,11 +108,13 @@ import { runHealthServer } from '../../../shared/runHealthServer';
       for (const domainEvent of domainEvents) {
         publishDomainEvent({ domainEvent });
 
-        await priorityQueueStoreForDomainEvents.enqueue({
-          item: domainEvent,
-          discriminator: domainEvent.aggregateIdentifier.id,
-          priority: domainEvent.metadata.timestamp
-        });
+        for (const flowName of Object.keys(application.flows)) {
+          await priorityQueueStoreForDomainEvents.enqueue({
+            item: domainEvent,
+            discriminator: flowName,
+            priority: domainEvent.metadata.timestamp
+          });
+        }
       }
     };
 

--- a/lib/runtimes/singleProcess/processes/main/fetchCommand.ts
+++ b/lib/runtimes/singleProcess/processes/main/fetchCommand.ts
@@ -1,5 +1,6 @@
 import { CommandData } from '../../../../common/elements/CommandData';
 import { CommandWithMetadata } from '../../../../common/elements/CommandWithMetadata';
+import { LockMetadata } from '../../../../stores/priorityQueueStore/LockMetadata';
 import { PriorityQueue } from './PriorityQueue';
 import { retry } from 'retry-ignore-abort';
 
@@ -9,10 +10,10 @@ const fetchCommand = async function ({ priorityQueue }: {
     command: CommandWithMetadata<CommandData>;
     token: string;
   }> {
-  const { item, token } = await retry(
+  const { item, metadata } = await retry(
     async (): Promise<{
       item: CommandWithMetadata<CommandData>;
-      token: string;
+      metadata: LockMetadata;
     }> => {
       const lock = await priorityQueue.store.lockNext();
 
@@ -25,7 +26,7 @@ const fetchCommand = async function ({ priorityQueue }: {
     { retries: Number.POSITIVE_INFINITY, maxTimeout: 1000 }
   );
 
-  return { command: item, token };
+  return { command: item, token: metadata.token };
 };
 
 export {

--- a/lib/runtimes/singleProcess/processes/main/getConfiguration.ts
+++ b/lib/runtimes/singleProcess/processes/main/getConfiguration.ts
@@ -57,11 +57,26 @@ const getConfiguration = function (): Configuration {
       default: 'InMemory',
       schema: { type: 'string' }
     },
-    PRIORITY_QUEUE_STORE_TYPE: {
+    PRIORITY_QUEUE_STORE_FOR_COMMANDS_TYPE: {
       default: 'InMemory',
       schema: { type: 'string', minLength: 1 }
     },
-    PRIORITY_QUEUE_STORE_OPTIONS: {
+    PRIORITY_QUEUE_STORE_FOR_COMMANDS_OPTIONS: {
+      default: { expirationTime: 30_000 },
+      schema: {
+        type: 'object',
+        properties: {
+          expirationTime: { type: 'number', minimum: 1 }
+        },
+        required: [ 'expirationTime' ],
+        additionalProperties: true
+      }
+    },
+    PRIORITY_QUEUE_STORE_FOR_DOMAIN_EVENTS_TYPE: {
+      default: 'InMemory',
+      schema: { type: 'string', minLength: 1 }
+    },
+    PRIORITY_QUEUE_STORE_FOR_DOMAIN_EVENTS_OPTIONS: {
       default: { expirationTime: 30_000 },
       schema: {
         type: 'object',

--- a/lib/stores/priorityQueueStore/InMemory/InMemoryPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/InMemory/InMemoryPriorityQueueStore.ts
@@ -3,6 +3,7 @@ import { errors } from '../../../common/errors';
 import { getIndexOfLeftChild } from '../shared/getIndexOfLeftChild';
 import { getIndexOfParent } from '../shared/getIndexOfParent';
 import { getIndexOfRightChild } from '../shared/getIndexOfRightChild';
+import { LockMetadata } from '../LockMetadata';
 import PQueue from 'p-queue';
 import { PriorityQueueStore } from '../PriorityQueueStore';
 import { Queue } from './Queue';
@@ -205,7 +206,7 @@ class InMemoryPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
     );
   }
 
-  protected lockNextInternal (): { item: TItem; token: string } | undefined {
+  protected lockNextInternal (): { item: TItem; metadata: LockMetadata} | undefined {
     if (this.queues.length === 0) {
       return;
     }
@@ -225,12 +226,12 @@ class InMemoryPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
 
     this.repairDown({ queue });
 
-    return { item: item.item, token };
+    return { item: item.item, metadata: { discriminator: queue.discriminator, token }};
   }
 
-  public async lockNext (): Promise<{ item: TItem; token: string } | undefined> {
+  public async lockNext (): Promise<{ item: TItem; metadata: LockMetadata } | undefined> {
     return await this.functionCallQueue.add(
-      async (): Promise<{ item: TItem; token: string } | undefined> => this.lockNextInternal()
+      async (): Promise<{ item: TItem; metadata: LockMetadata } | undefined> => this.lockNextInternal()
     );
   }
 

--- a/lib/stores/priorityQueueStore/LockMetadata.ts
+++ b/lib/stores/priorityQueueStore/LockMetadata.ts
@@ -1,0 +1,4 @@
+export interface LockMetadata {
+  discriminator: string;
+  token: string;
+}

--- a/lib/stores/priorityQueueStore/PriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/PriorityQueueStore.ts
@@ -1,6 +1,8 @@
+import { LockMetadata } from './LockMetadata';
+
 // The priority queues implementing this interface are based on a heap data
-// structure, where items with smaller priorities tend to become closer to the
-// root node. Hence, this represents a min-heap.
+// structure, where items with smaller priorities move closer to the root node.
+// Hence, this represents a min-heap.
 export interface PriorityQueueStore<TItem, TItemIdentifier> {
   enqueue ({ item, discriminator, priority }: {
     item: TItem;
@@ -8,7 +10,10 @@ export interface PriorityQueueStore<TItem, TItemIdentifier> {
     priority: number;
   }): Promise<void>;
 
-  lockNext (): Promise<{ item: TItem; token: string } | undefined>;
+  lockNext (): Promise<{
+    item: TItem;
+    metadata: LockMetadata;
+  } | undefined>;
 
   renewLock ({ discriminator, token }: {
     discriminator: string;

--- a/test/runtime/microservice/processes/domainEventDispatcher/processTests.ts
+++ b/test/runtime/microservice/processes/domainEventDispatcher/processTests.ts
@@ -1,0 +1,131 @@
+import { assert } from 'assertthat';
+import { Client as AwaitDomainEventClient } from '../../../../../lib/apis/awaitItem/http/v2/Client';
+import { buildDomainEvent } from '../../../../../lib/common/utils/test/buildDomainEvent';
+import { DomainEvent } from '../../../../../lib/common/elements/DomainEvent';
+import { DomainEventData } from '../../../../../lib/common/elements/DomainEventData';
+import { getAvailablePorts } from '../../../../../lib/common/utils/network/getAvailablePorts';
+import { getTestApplicationDirectory } from '../../../../shared/applications/getTestApplicationDirectory';
+import { Client as HealthClient } from '../../../../../lib/apis/getHealth/http/v2/Client';
+import { ItemIdentifier } from '../../../../../lib/common/elements/ItemIdentifier';
+import { Client as PublishMessageClient } from '../../../../../lib/apis/publishMessage/http/v2/Client';
+import { startProcess } from '../../../../../lib/runtimes/shared/startProcess';
+import { uuid } from 'uuidv4';
+
+suite('domainEventDispatcher', function (): void {
+  this.timeout(10 * 1000);
+
+  const applicationDirectory = getTestApplicationDirectory({ name: 'base' });
+
+  const queueLockExpirationTime = 600;
+
+  let awaitDomainEventClient: AwaitDomainEventClient<DomainEvent<DomainEventData>, ItemIdentifier>,
+      healthPortDomainEventDispatcher: number,
+      healthPortPublisher: number,
+      portDomainEventDispatcher: number,
+      portPublisher: number,
+      publishMessageClient: PublishMessageClient,
+      stopProcessDomainEventDispatcher: (() => Promise<void>) | undefined,
+      stopProcessPublisher: (() => Promise<void>) | undefined;
+
+  setup(async (): Promise<void> => {
+    [ portDomainEventDispatcher, healthPortDomainEventDispatcher, portPublisher, healthPortPublisher ] = await getAvailablePorts({ count: 4 });
+
+    stopProcessPublisher = await startProcess({
+      runtime: 'microservice',
+      name: 'publisher',
+      enableDebugMode: false,
+      port: healthPortPublisher,
+      env: {
+        PORT: String(portPublisher),
+        HEALTH_PORT: String(healthPortPublisher)
+      }
+    });
+
+    publishMessageClient = new PublishMessageClient({
+      protocol: 'http',
+      hostName: 'localhost',
+      port: portPublisher,
+      path: '/publish/v2'
+    });
+
+    stopProcessDomainEventDispatcher = await startProcess({
+      runtime: 'microservice',
+      name: 'domainEventDispatcher',
+      enableDebugMode: false,
+      port: healthPortDomainEventDispatcher,
+      env: {
+        APPLICATION_DIRECTORY: applicationDirectory,
+        PRIORITY_QUEUE_STORE_OPTIONS: `{"expirationTime":${queueLockExpirationTime}}`,
+        PORT: String(portDomainEventDispatcher),
+        HEALTH_PORT: String(healthPortDomainEventDispatcher),
+        SUBSCRIBE_MESSAGES_PROTOCOL: 'http',
+        SUBSCRIBE_MESSAGES_HOST_NAME: 'localhost',
+        SUBSCRIBE_MESSAGES_PORT: String(portPublisher),
+        SUBSCRIBE_MESSAGES_CHANNEL: 'newDomainEventInternal'
+      }
+    });
+
+    awaitDomainEventClient = new AwaitDomainEventClient({
+      protocol: 'http',
+      hostName: 'localhost',
+      port: portDomainEventDispatcher,
+      path: '/await-domain-event/v2',
+      createItemInstance: ({ item }: { item: DomainEvent<DomainEventData> }): DomainEvent<DomainEventData> => new DomainEvent<DomainEventData>(item)
+    });
+  });
+
+  teardown(async (): Promise<void> => {
+    if (stopProcessDomainEventDispatcher) {
+      await stopProcessDomainEventDispatcher();
+    }
+    if (stopProcessPublisher) {
+      await stopProcessPublisher();
+    }
+
+    stopProcessPublisher = undefined;
+    stopProcessDomainEventDispatcher = undefined;
+  });
+
+  suite('getHealth', (): void => {
+    test('is using the health API.', async (): Promise<void> => {
+      const healthClient = new HealthClient({
+        protocol: 'http',
+        hostName: 'localhost',
+        port: healthPortDomainEventDispatcher,
+        path: '/health/v2'
+      });
+
+      await assert.that(
+        async (): Promise<any> => healthClient.getHealth()
+      ).is.not.throwingAsync();
+    });
+  });
+
+  suite('awaitDomainEvent', (): void => {
+    test('delivers a domain event that is sent to the publisher.', async (): Promise<void> => {
+      const domainEvent = buildDomainEvent({
+        contextIdentifier: {
+          name: 'sampleContext'
+        },
+        aggregateIdentifier: {
+          name: 'sampleAggregate',
+          id: uuid()
+        },
+        name: 'executed',
+        data: { strategy: 'succeed' },
+        metadata: {
+          revision: 1
+        }
+      });
+
+      await publishMessageClient.postMessage({
+        channel: 'newDomainEventInternal',
+        message: domainEvent
+      });
+
+      const lock = await awaitDomainEventClient.awaitItem();
+
+      assert.that(lock.item).is.equalTo(domainEvent);
+    });
+  });
+});

--- a/test/unit/apis/awaitItem/ClientTests.ts
+++ b/test/unit/apis/awaitItem/ClientTests.ts
@@ -88,7 +88,7 @@ suite('awaitItem/http/Client', (): void => {
 
         await priorityQueueStore.enqueue({
           item: commandWithMetadata,
-          discriminator: commandWithMetadata.aggregateIdentifier.id,
+          discriminator: 'foo',
           priority: commandWithMetadata.metadata.timestamp
         });
         await newItemPublisher.publish({
@@ -99,7 +99,8 @@ suite('awaitItem/http/Client', (): void => {
         const command = await client.awaitItem();
 
         assert.that(command.item).is.equalTo(commandWithMetadata);
-        assert.that(command.token).is.ofType('string');
+        assert.that(command.metadata.token).is.ofType('string');
+        assert.that(command.metadata.discriminator).is.equalTo('foo');
       });
     });
 
@@ -261,7 +262,7 @@ suite('awaitItem/http/Client', (): void => {
           message: {}
         });
 
-        const { item, token } = await client.awaitItem();
+        const { item, metadata: { token }} = await client.awaitItem();
 
         await sleep({ ms: 0.6 * expirationTime });
 
@@ -448,7 +449,7 @@ suite('awaitItem/http/Client', (): void => {
           priority: commandTwo.metadata.timestamp
         });
 
-        const { item, token } = await client.awaitItem();
+        const { item, metadata: { token }} = await client.awaitItem();
 
         const commandWithMetadata = new CommandWithMetadata(item);
 
@@ -638,7 +639,7 @@ suite('awaitItem/http/Client', (): void => {
           priority: commandTwo.metadata.timestamp
         });
 
-        const { item, token } = await client.awaitItem();
+        const { item, metadata: { token }} = await client.awaitItem();
 
         const commandWithMetadata = new CommandWithMetadata(item);
 
@@ -648,7 +649,7 @@ suite('awaitItem/http/Client', (): void => {
           priority: Date.now()
         });
 
-        const { item: nextItem, token: nextToken } = await client.awaitItem();
+        const { item: nextItem, metadata: { token: nextToken }} = await client.awaitItem();
 
         const nextCommandWithMetadata = new CommandWithMetadata(nextItem);
 

--- a/test/unit/apis/awaitItem/httpTests.ts
+++ b/test/unit/apis/awaitItem/httpTests.ts
@@ -162,7 +162,7 @@ suite('awaitItem/http', (): void => {
             },
             (streamElement: any): void => {
               assert.that(streamElement.item).is.equalTo(commandWithMetadata);
-              assert.that(isUuid(streamElement.token)).is.true();
+              assert.that(isUuid(streamElement.metadata.token)).is.true();
             }
           ]));
         });
@@ -208,7 +208,7 @@ suite('awaitItem/http', (): void => {
             },
             (streamElement: any): void => {
               assert.that(streamElement.item).is.equalTo(commandWithMetadata);
-              assert.that(isUuid(streamElement.token)).is.true();
+              assert.that(isUuid(streamElement.metadata.token)).is.true();
 
               resolve();
             }
@@ -234,7 +234,7 @@ suite('awaitItem/http', (): void => {
             },
             (streamElement: any): void => {
               assert.that(streamElement.item).is.equalTo(commandWithMetadata);
-              assert.that(isUuid(streamElement.token)).is.true();
+              assert.that(isUuid(streamElement.metadata.token)).is.true();
 
               resolve();
             }
@@ -429,7 +429,7 @@ suite('awaitItem/http', (): void => {
           responseType: 'stream'
         });
 
-        const { token } = await new Promise((resolve, reject): void => {
+        const { metadata: { token }} = await new Promise((resolve, reject): void => {
           lockData.on('error', (err: any): void => {
             reject(err);
           });
@@ -609,7 +609,7 @@ suite('awaitItem/http', (): void => {
           responseType: 'stream'
         });
 
-        const { item, token } = await new Promise((resolve, reject): void => {
+        const { item, metadata: { token }} = await new Promise((resolve, reject): void => {
           firstLockData.on('error', (err: any): void => {
             reject(err);
           });
@@ -812,7 +812,7 @@ suite('awaitItem/http', (): void => {
           responseType: 'stream'
         });
 
-        const { item, token } = await new Promise((resolve, reject): void => {
+        const { item, metadata: { token }} = await new Promise((resolve, reject): void => {
           firstLockData.on('error', (err: any): void => {
             reject(err);
           });
@@ -846,7 +846,7 @@ suite('awaitItem/http', (): void => {
           responseType: 'stream'
         });
 
-        const { item: nextItem, token: nextToken } = await new Promise((resolve, reject): void => {
+        const { item: nextItem, metadata: { token: nextToken }} = await new Promise((resolve, reject): void => {
           secondLockData.on('error', (err: any): void => {
             reject(err);
           });


### PR DESCRIPTION
The domain event dispatcher is the new connection piece between the domain servers and the flow servers. Although there is one more indirection in there.

So far the domain servers have published new domain events via the publisher server. The publisher server had only one channel for messages for a while but since #968 clients of the publisher server can send messages on specific channels and domain events have since then been sent (by default) via the `newDomainEvent` channel. These domain events were so far received by the domain server and the graphql server and published to outside clients.

The flow server must not only receive all newly published domain events live from the publisher server - it must also be able to receive replays of events, which are not meant for outside clients. So if the domain event dispatcher was going to receive its domain events via the publisher server, a new channel was needed. To achive this, the domain servers now publish new domain events twice: (by default) on the channels `newDomainEvent` and `newDomainEventInternal`.

The latter channel will in the future also be used to replay domain events to catch up new flows.