### PR TITLE
fix: Convert item from priority queue to actual CommandWithMetadata.

### DIFF
--- a/lib/runtimes/singleProcess/processes/main/domain/fetchCommand.ts
+++ b/lib/runtimes/singleProcess/processes/main/domain/fetchCommand.ts
@@ -26,7 +26,7 @@ const fetchCommand = async function ({ priorityQueue }: {
     { retries: Number.POSITIVE_INFINITY, minTimeout: 10, maxTimeout: 500 }
   );
 
-  return { command: item, metadata };
+  return { command: new CommandWithMetadata<CommandData>(item), metadata };
 };
 
 export {


### PR DESCRIPTION
This fixes the issue Dominique raised in the wolkenkit Slack, where the postgres priority queue store seemed broken.

The issue was not with the store implementation, but a problem that all persistent priority queues share: When retrieving an item from them, it's just an object and thus has to be converted to a CommandWithMetadata instance (or for whatever the priority queue is used). This was missing for commands in the single process runtime.
