### PR TITLE
fix: blank template sampleView needs item schema

### DIFF
--- a/templates/blank/javascript/server/views/sampleView/queries/all.js
+++ b/templates/blank/javascript/server/views/sampleView/queries/all.js
@@ -8,14 +8,20 @@ const all = {
   getResultItemSchema () {
     return {
       type: 'object',
-      properties: {},
+      properties: {
+        id: { type: 'number' },
+        task: { type: 'string' }
+      },
       required: [],
       additionalProperties: false
     };
   },
 
   async handle () {
-    return Readable.from([]);
+    return Readable.from([
+      { id: 1, task: 'task 1' },
+      { id: 2, task: 'task 2' }
+    ]);
   },
 
   isAuthorized () {

--- a/templates/blank/typescript/server/views/sampleView/queries/all.ts
+++ b/templates/blank/typescript/server/views/sampleView/queries/all.ts
@@ -10,14 +10,20 @@ export const all: QueryHandler<AllResultItem, Infrastructure> = {
   getResultItemSchema (): Schema {
     return {
       type: 'object',
-      properties: {},
+      properties: {
+        id: { type: 'number' },
+        task: { type: 'string' }
+      },
       required: [],
       additionalProperties: false
     };
   },
 
   async handle (): Promise<Readable> {
-    return Readable.from([]);
+    return Readable.from([
+      { id: 1, task: 'task 1' },
+      { id: 2, task: 'task 2' }
+    ]);
   },
 
   isAuthorized (): boolean {


### PR DESCRIPTION
This commit will fix:

`An unexpected error occured. (fatal)
Nil-mbp.local::wolkenkit@4.0.0-internal.58 (/Users/Nil/Workspace/sources/wolkenkit/build/lib/runtimes/singleProcess/processes/main/app.js)
19:04:43.346@2020-07-22 24744#1
{
  ex: {
    name: 'Error',
    message: 'Type SampleView_all_resultItemT0 must define one or more fields.',
    stack: 'Error: Type SampleView_all_resultItemT0 must define one or more fields.
    at assertValidSchema (/Users/Nil/Workspace/sources/wolkenkit/node_modules/graphql/type/validate.js:71:11)
    at assertValidExecutionArguments (/Users/Nil/Workspace/sources/wolkenkit/node_modules/graphql/execution/execute.js:153:35)
    at executeImpl (/Users/Nil/Workspace/sources/wolkenkit/node_modules/graphql/execution/execute.js:101:3)
    at Object.execute (/Users/Nil/Workspace/sources/wolkenkit/node_modules/graphql/execution/execute.js:63:63)
    at Object.generateSchemaHash (/Users/Nil/Workspace/sources/wolkenkit/node_modules/apollo-server-core/dist/utils/schemaHash.js:15:32)
    at ApolloServer.generateSchemaDerivedData (/Users/Nil/Workspace/sources/wolkenkit/node_modules/apollo-server-core/dist/ApolloServer.js:282:41)
    at new ApolloServerBase (/Users/Nil/Workspace/sources/wolkenkit/node_modules/apollo-server-core/dist/ApolloServer.js:196:38)
    at new ApolloServer (/Users/Nil/Workspace/sources/wolkenkit/node_modules/apollo-server-express/dist/ApolloServer.js:60:9)
    at Object.getV2 (/Users/Nil/Workspace/sources/wolkenkit/build/lib/apis/graphql/v2/index.js:31:27)
    at async Object.getApi (/Users/Nil/Workspace/sources/wolkenkit/build/lib/apis/graphql/index.js:11:16)'
  }
}`