### PR TITLE
fix: Check application part existence and handle specific errors.

### DIFF
--- a/lib/common/application/getHooksDefinition.ts
+++ b/lib/common/application/getHooksDefinition.ts
@@ -20,6 +20,9 @@ const getHooksDefinition = async function ({ hooksDirectory }: {
     if (ex instanceof SyntaxError) {
       throw new errors.ApplicationMalformed(`Syntax error in '<app>/build/server/hooks'.`, { cause: ex });
     }
+    if (ex.code === 'MODULE_NOT_FOUND') {
+      throw new errors.ApplicationMalformed(`Missing import in '<app>/build/server/hooks'.`, { cause: ex });
+    }
 
     // But throw an error if the entry is a directory without importable content.
     throw new errors.FileNotFound(`No hooks definition in '<app>/build/server/hooks' found.`);

--- a/lib/common/application/getInfrastructureDefinition.ts
+++ b/lib/common/application/getInfrastructureDefinition.ts
@@ -20,6 +20,9 @@ const getInfrastructureDefinition = async function ({ infrastructureDirectory }:
     if (ex instanceof SyntaxError) {
       throw new errors.ApplicationMalformed(`Syntax error in '<app>/build/server/infrastructure'.`, { cause: ex });
     }
+    if (ex.code === 'MODULE_NOT_FOUND') {
+      throw new errors.ApplicationMalformed(`Missing import in '<app>/build/server/infrastructure'.`, { cause: ex });
+    }
 
     // But throw an error if the entry is a directory without importable content.
     throw new errors.FileNotFound(`No infrastructure definition in '<app>/build/server/infrastructure' found.`);

--- a/lib/common/application/getNotificationsDefinition.ts
+++ b/lib/common/application/getNotificationsDefinition.ts
@@ -18,6 +18,9 @@ const getNotificationsDefinition = async function ({ notificationsDirectory }: {
     if (ex instanceof SyntaxError) {
       throw new errors.ApplicationMalformed(`Syntax error in '<app>/build/server/notifications'.`, { cause: ex });
     }
+    if (ex.code === 'MODULE_NOT_FOUND') {
+      throw new errors.ApplicationMalformed(`Missing import in '<app>/build/server/notifications'.`, { cause: ex });
+    }
 
     // But throw an error if the entry is a directory without importable content.
     throw new errors.FileNotFound(`No notifications definition in '<app>/build/server/notifications' found.`);

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/SampleState.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/SampleState.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const getInitialState = function () {
+  return {
+    domainEventNames: []
+  };
+};
+
+module.exports = {
+  getInitialState
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/commands/authorize.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/commands/authorize.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const authorize = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {
+        shouldAuthorize: { type: 'boolean' }
+      },
+      required: [ 'shouldAuthorize' ],
+      additionalProperties: false
+    };
+  },
+
+  isAuthorized (state, command) {
+    // Reject authorization if we cannot see the state properties. That allows
+    // to verify that `handleCommand` passes the state value instead of the
+    // `CurrentAggregateState` wrapper object.
+    if (!state.domainEventNames) {
+      return false;
+    }
+
+    return command.data.shouldAuthorize;
+  },
+
+  handle (state, command, { aggregate }) {
+    aggregate.publishDomainEvent('authorized', {});
+  }
+};
+
+module.exports = {
+  authorize
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/commands/execute.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/commands/execute.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const execute = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {
+        strategy: { type: 'string', enum: [ 'succeed', 'fail', 'reject' ]}
+      },
+      required: [ 'strategy' ],
+      additionalProperties: false
+    };
+  },
+
+  isAuthorized () {
+    return true;
+  },
+
+  handle (state, command, { aggregate, error, notification }) {
+    const { strategy } = command.data;
+
+    if (strategy === 'fail') {
+      throw new Error('Intentionally failed execute.');
+    }
+
+    if (strategy === 'reject') {
+      throw new error.CommandRejected('Intentionally rejected execute.');
+    }
+
+    aggregate.publishDomainEvent('succeeded', {});
+    aggregate.publishDomainEvent('executed', { strategy });
+
+    notification.publish('commandExecute', {});
+  }
+};
+
+module.exports = {
+  execute
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/authenticated.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/authenticated.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const authenticated = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    };
+  },
+
+  handle (state) {
+    return {
+      domainEventNames: [ ...state.domainEventNames, 'authenticated' ]
+    };
+  },
+
+  isAuthorized (state, domainEvent, { client }) {
+    return client.user.claims.iss !== 'https://token.invalid';
+  }
+};
+
+module.exports = {
+  authenticated
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/authorized.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/authorized.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const authorized = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    };
+  },
+
+  handle (state) {
+    return {
+      domainEventNames: [ ...state.domainEventNames, 'authorized' ]
+    };
+  },
+
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = {
+  authorized
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/executed.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/executed.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const executed = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {
+        strategy: { type: 'string', enum: [ 'succeed', 'fail', 'reject' ]}
+      },
+      required: [ 'strategy' ],
+      additionalProperties: false
+    };
+  },
+
+  handle (state) {
+    return {
+      domainEventNames: [ ...state.domainEventNames, 'executed' ]
+    };
+  },
+
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = {
+  executed
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/succeeded.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/domainEvents/succeeded.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const succeeded = {
+  getSchema () {
+    return {
+      type: 'object',
+      properties: {},
+      additionalProperties: false
+    };
+  },
+
+  handle (state) {
+    return {
+      domainEventNames: [ ...state.domainEventNames, 'succeeded' ]
+    };
+  },
+
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = {
+  succeeded
+};

--- a/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/domain/sampleContext/sampleAggregate/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { authenticate } = require('./commands/authenticate'),
+      { authorize } = require('./commands/authorize'),
+      { execute } = require('./commands/execute'),
+      { authenticated } = require('./domainEvents/authenticated'),
+      { authorized } = require('./domainEvents/authorized'),
+      { executed } = require('./domainEvents/executed'),
+      { succeeded } = require('./domainEvents/succeeded'),
+      { getInitialState } = require('./SampleState');
+
+const sampleAggregate = {
+  getInitialState,
+  commandHandlers: {
+    authenticate,
+    authorize,
+    execute
+  },
+  domainEventHandlers: {
+    authenticated,
+    authorized,
+    succeeded,
+    executed
+  }
+};
+
+module.exports = sampleAggregate;

--- a/test/shared/applications/javascript/withMissingModule/build/server/flows/sampleFlow/handlers/sampleHandler.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/flows/sampleFlow/handlers/sampleHandler.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const sampleHandler = {
+  isRelevant ({ fullyQualifiedName }) {
+    return fullyQualifiedName === 'sampleContext.sampleAggregate.executed';
+  },
+
+  handle (domainEvent, { infrastructure, logger, notification }) {
+    logger.info('Received domain event.', { domainEvent });
+
+    infrastructure.tell.viewStore.domainEvents.push({
+      contextIdentifier: domainEvent.contextIdentifier,
+      aggregateIdentifier: domainEvent.aggregateIdentifier,
+      name: domainEvent.name,
+      id: domainEvent.id
+    });
+
+    notification.publish('flowSampleFlowUpdated', {});
+  }
+};
+
+module.exports = { sampleHandler };

--- a/test/shared/applications/javascript/withMissingModule/build/server/flows/sampleFlow/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/flows/sampleFlow/index.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { sampleHandler } = require('./handlers/sampleHandler');
+
+const sampleFlow = {
+  replayPolicy: 'never',
+
+  domainEventHandlers: {
+    sampleHandler
+  }
+};
+
+module.exports = sampleFlow;

--- a/test/shared/applications/javascript/withMissingModule/build/server/hooks/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/hooks/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const hooks = {
+  // Intentionally left blank.
+};
+
+module.exports = hooks;

--- a/test/shared/applications/javascript/withMissingModule/build/server/infrastructure/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/infrastructure/index.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const setupInfrastructure = async function () {
+  // Intentionally left blank.
+};
+
+const getInfrastructure = async function () {
+  const domainEvents = [];
+
+  return {
+    ask: {
+      viewStore: {
+        domainEvents
+      }
+    },
+    tell: {
+      viewStore: {
+        domainEvents
+      }
+    }
+  };
+};
+
+module.exports = { getInfrastructure, setupInfrastructure };

--- a/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/commandExecuteNotificationHandler.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/commandExecuteNotificationHandler.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const commandExecuteNotificationHandler = {
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = { commandExecuteNotificationHandler };

--- a/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/complexNotificationHandler.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/complexNotificationHandler.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const complexNotificationHandler = {
+  getDataSchema () {
+    return {
+      type: 'object',
+      properties: {
+        message: { type: 'string', minLength: 1 }
+      },
+      required: [ 'message' ]
+    };
+  },
+
+  getMetadataSchema () {
+    return {
+      type: 'object',
+      properties: {
+        public: { type: 'boolean' }
+      },
+      required: [ 'public' ]
+    };
+  },
+
+  isAuthorized (data, metadata) {
+    return metadata.public;
+  }
+};
+
+module.exports = { complexNotificationHandler };

--- a/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/flowSampleFlowUpdatedNotificationHandler.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/flowSampleFlowUpdatedNotificationHandler.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const flowSampleFlowUpdatedNotificationHandler = {
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = { flowSampleFlowUpdatedNotificationHandler };

--- a/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/viewSampleViewUpdatedNotificationHandler.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/notifications/handlers/viewSampleViewUpdatedNotificationHandler.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const viewSampleViewUpdatedNotificationHandler = {
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = { viewSampleViewUpdatedNotificationHandler };

--- a/test/shared/applications/javascript/withMissingModule/build/server/notifications/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/notifications/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { commandExecuteNotificationHandler } = require('./handlers/commandExecuteNotificationHandler'),
+      { complexNotificationHandler } = require('./handlers/complexNotificationHandler'),
+      { flowSampleFlowUpdatedNotificationHandler } = require('./handlers/flowSampleFlowUpdatedNotificationHandler'),
+      { viewSampleViewUpdatedNotificationHandler } = require('./handlers/viewSampleViewUpdatedNotificationHandler');
+
+const notifications = {
+  commandExecute: commandExecuteNotificationHandler,
+  complex: complexNotificationHandler,
+  flowSampleFlowUpdated: flowSampleFlowUpdatedNotificationHandler,
+  viewSampleViewUpdated: viewSampleViewUpdatedNotificationHandler
+};
+
+module.exports = notifications;

--- a/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/index.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { all } = require('./queries/all'),
+      { flowSampleFlowUpdatedNotificationSubscriber } = require('./notificationSubscribers/flowSampleFlowUpdatedNotificationSubscriber');
+
+const sampleView = {
+  queryHandlers: {
+    all
+  },
+  notificationSubscribers: {
+    flowSampleFlowUpdatedNotificationSubscriber
+  }
+};
+
+module.exports = sampleView;

--- a/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/notificationSubscribers/flowSampleFlowUpdatedNotificationSubscriber.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/notificationSubscribers/flowSampleFlowUpdatedNotificationSubscriber.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const flowSampleFlowUpdatedNotificationSubscriber = {
+  isRelevant ({ name }) {
+    return name === 'flowSampleFlowUpdated';
+  },
+
+  handle (data, { notification }) {
+    notification.publish('viewSampleViewUpdated', {});
+  }
+};
+
+module.exports = { flowSampleFlowUpdatedNotificationSubscriber };

--- a/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/queries/all.js
+++ b/test/shared/applications/javascript/withMissingModule/build/server/views/sampleView/queries/all.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { Readable } = require('stream');
+
+const all = {
+  type: 'stream',
+
+  getResultItemSchema () {
+    return {
+      type: 'object',
+      properties: {
+        contextIdentifier: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', minLength: 1 }
+          },
+          required: [ 'name' ],
+          additionalProperties: false
+        },
+        aggregateIdentifier: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', minLength: 1 },
+            id: { type: 'string' }
+          },
+          required: [ 'name', 'id' ],
+          additionalProperties: false
+        },
+        name: { type: 'string', minLength: 1 },
+        id: { type: 'string' }
+      },
+      required: [ 'contextIdentifier', 'aggregateIdentifier', 'name', 'id' ],
+      additionalProperties: false
+    };
+  },
+
+  async handle (options, { infrastructure }) {
+    return Readable.from(infrastructure.ask.viewStore.domainEvents);
+  },
+
+  isAuthorized () {
+    return true;
+  }
+};
+
+module.exports = { all };

--- a/test/shared/applications/javascript/withMissingModule/package.json
+++ b/test/shared/applications/javascript/withMissingModule/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "withMissingModule",
+  "version": "1.0.0"
+}

--- a/test/unit/common/application/loadApplicationTests.ts
+++ b/test/unit/common/application/loadApplicationTests.ts
@@ -280,4 +280,12 @@ suite('loadApplication', (): void => {
       that(async (): Promise<any> => loadApplication({ applicationDirectory })).
       is.throwingAsync((ex): boolean => (ex as CustomError).code === errors.ApplicationMalformed.code);
   });
+
+  test('throws an appropriate error if any file in the application tries to import a non existent module.', async (): Promise<void> => {
+    const applicationDirectory = getTestApplicationDirectory({ name: 'withMissingModule' });
+
+    await assert.
+      that(async (): Promise<any> => loadApplication({ applicationDirectory })).
+      is.throwingAsync((ex): boolean => (ex as CustomError).code === errors.ApplicationMalformed.code);
+  });
 });


### PR DESCRIPTION
This closes #1215.

I've decided to check whether the folders which are imported contain an `index.js` before attempting to import them.

Otherwise it would have been too complicated to differentiate between a `MODULE_NOT_FOUND` error thrown because of a missing `index.js` or because of a faulty import in the application.