### PR TITLE
fix: Fix priority queue acknowledge in multiple databases.

### DIFF
--- a/lib/stores/priorityQueueStore/Postgres/PostgresPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/Postgres/PostgresPriorityQueueStore.ts
@@ -292,17 +292,15 @@ class PostgresPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
         firstQueue: queue,
         secondQueue: leftChildQueue
       });
-
-      await this.repairDown({ connection, discriminator: queue.discriminator });
     } else {
       await this.swapPositionsInPriorityQueue({
         connection,
         firstQueue: queue,
         secondQueue: rightChildQueue!
       });
-
-      await this.repairDown({ connection, discriminator: queue.discriminator });
     }
+
+    await this.repairDown({ connection, discriminator: queue.discriminator });
   }
 
   protected async removeQueueInternal ({ connection, discriminator }: {
@@ -327,24 +325,31 @@ class PostgresPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
       text: `
         DELETE FROM "${this.tableNames.priorityQueue}"
           WHERE "discriminator" = $1;
-          `,
+      `,
       values: [ discriminator ]
     });
-    const { rowCount } = await connection.query({
+
+    const { rows: [{ count }] } = await connection.query({
+      name: 'check how many queues are left in the priority queue',
+      text: `
+        SELECT count(*) as count
+          FROM "${this.tableNames.priorityQueue}";
+      `
+    });
+
+    if (rows[0].indexInPriorityQueue >= count) {
+      return;
+    }
+
+    await connection.query({
       name: 'move last queue in priority queue to index of removed queue',
       text: `
         UPDATE "${this.tableNames.priorityQueue}"
           SET "indexInPriorityQueue" = $1
-          WHERE "indexInPriorityQueue" = (SELECT MAX("indexInPriorityQueue") FROM "${this.tableNames.priorityQueue}");
+          WHERE "indexInPriorityQueue" = $2;
       `,
-      values: [ rows[0].indexInPriorityQueue ]
+      values: [ rows[0].indexInPriorityQueue, count ]
     });
-
-    // If the update did not change any rows, we removed the last queue and
-    // don't have to repair.
-    if (rowCount === 0) {
-      return;
-    }
 
     const { rows: [{ discriminator: movedQueueDiscriminator }] } = await connection.query({
       name: 'get discriminator of moved queue',

--- a/lib/stores/priorityQueueStore/Postgres/PostgresPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/Postgres/PostgresPriorityQueueStore.ts
@@ -134,7 +134,7 @@ class PostgresPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
               "priority" bigint NOT NULL,
               "item" jsonb NOT NULL,
 
-              CONSTRAINT "${tableNames.items}_pk" PRIMARY KEY ("discriminator", "indexInQueue")
+              CONSTRAINT "${tableNames.items}_pk" PRIMARY KEY ("discriminator", "indexInQueue") DEFERRABLE
             );
           `
         });
@@ -674,6 +674,11 @@ class PostgresPriorityQueueStore<TItem, TItemIdentifier> implements PriorityQueu
             AND "indexInQueue" = 0;
       `,
       values: [ queue.discriminator ]
+    });
+
+    await connection.query({
+      name: 'defer constraints for following bulk update',
+      text: `SET CONSTRAINTS "${this.tableNames.items}_pk" DEFERRED`
     });
 
     const { rowCount } = await connection.query({

--- a/test/integration/stores/priorityQueueStore/getTestsFor.ts
+++ b/test/integration/stores/priorityQueueStore/getTestsFor.ts
@@ -6,9 +6,11 @@ import { CustomError } from 'defekt';
 import { errors } from '../../../../lib/common/errors';
 import { getShortId } from '../../../shared/getShortId';
 import { ItemIdentifierWithClient } from '../../../../lib/common/elements/ItemIdentifierWithClient';
+import pForever from 'p-forever';
 import { PriorityQueueStore } from '../../../../lib/stores/priorityQueueStore/PriorityQueueStore';
 import { sleep } from '../../../../lib/common/utils/sleep';
 import { v4 } from 'uuid';
+import { waitForSignals } from 'wait-for-signals';
 
 /* eslint-disable mocha/max-top-level-suites, mocha/no-top-level-hooks */
 const getTestsFor = function ({ createPriorityQueueStore }: {
@@ -809,6 +811,53 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
         priority: Math.floor(Math.random() * 1000),
         item: { index: 0 }
       });
+    });
+
+    test('can handle large amounts of random items in queues.', async function (): Promise<void> {
+      this.timeout(40_000);
+
+      const enqueues: any[] = [];
+
+      for (let i = 0; i < 150; i++) {
+        enqueues.push({
+          discriminator: `${Math.floor(Math.random() * 5)}`,
+          priority: Math.floor(Math.random() * 1000),
+          item: { id: v4() }
+        });
+      }
+
+      for (const enqueue of enqueues) {
+        await priorityQueueStore.enqueue(enqueue);
+      }
+
+      const parallelism = 5;
+      const counter = waitForSignals({ count: parallelism });
+
+      for (let i = 0; i < parallelism; i++) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises,no-loop-func
+        pForever(async (): Promise<any> => {
+          try {
+            const nextLock = await priorityQueueStore.lockNext();
+
+            if (!nextLock) {
+              await counter.signal();
+
+              return pForever.end;
+            }
+
+            await sleep({ ms: Math.floor(Math.random() * 150) });
+
+            await priorityQueueStore.acknowledge({
+              discriminator: nextLock.metadata.discriminator,
+              token: nextLock.metadata.token
+            });
+          } catch (ex) {
+            await counter.fail(ex);
+          }
+        });
+      }
+
+      await counter.promise;
     });
   });
 };


### PR DESCRIPTION
- Fixes an old and known bug that was fixed in mongodb and inmemory but still existed in mysql, postgres and mssql. Removing a queue from the priority queue did not check wether the queue to remove was the last in the priority queue and messed up the removal.
- Fixes a bug in the postgres implementation where the bulk update that moved the items in a queue one place to the front after acknowledging an item would cause a unique key constraint violation.