### PR TITLE
fix: dev command ports are inconsistent with env

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,10 @@
     {
       "name": "Mike Cann",
       "email": "mike.cann@gmail.com"
+    },
+    {
+      "name": "Nil Lin",
+      "email": "nil@lin.am"
     }
   ],
   "main": "build/lib/wolkenkit.js",


### PR DESCRIPTION
`PORT=4000 HEALTH_PORT=4001 yarn wolkenkit dev`

will output:

```
  Starting the 'server' application...

    API port     3000
    Health port  3001

  To stop the 'server' application, press <Ctrl>+<C>.

...

Health server started. (info)
Nil-mbp.local::undefined@undefined::wolkenkit@4.0.0-internal.88 (/Users/Nil/Workspace/jsnews/scrapeland/node_modules/wolkenkit/build/lib/runtimes/shared/runHealthServer.js)
16:59:51.910@2020-12-28 30744#1
{
  healthPort: 4001
}
─────────────────────────────────
Single process runtime server started. (info)
Nil-mbp.local::undefined@undefined::wolkenkit@4.0.0-internal.88 (/Users/Nil/Workspace/jsnews/scrapeland/node_modules/wolkenkit/build/lib/runtimes/singleProcess/processes/main/app.js)
16:59:51.914@2020-12-28 30744#2
{
  port: 4000
}
─────────────────────────────────
✗ Failed to run the application.
  RetriesExceeded: Retried too many times.
...
```