### PR TITLE
fix: set utf8mb4 charset in MySQL connection options

### DIFF
--- a/lib/stores/consumerProgressStore/MySql/MySqlConsumerProgressStore.ts
+++ b/lib/stores/consumerProgressStore/MySql/MySqlConsumerProgressStore.ts
@@ -1,5 +1,6 @@
 import { AggregateIdentifier } from '../../../common/elements/AggregateIdentifier';
 import { ConsumerProgressStore } from '../ConsumerProgressStore';
+import { createPoolWithDefaults } from '../../utils/mySql/createPool';
 import { errors } from '../../../common/errors';
 import { getHash } from '../../../common/utils/crypto/getHash';
 import { IsReplaying } from '../IsReplaying';
@@ -8,7 +9,7 @@ import { retry } from 'retry-ignore-abort';
 import { runQuery } from '../../utils/mySql/runQuery';
 import { TableNames } from './TableNames';
 import { withTransaction } from '../../utils/mySql/withTransaction';
-import { createPool, MysqlError, Pool, PoolConnection } from 'mysql';
+import { MysqlError, Pool, PoolConnection } from 'mysql';
 
 class MySqlConsumerProgressStore implements ConsumerProgressStore {
   protected pool: Pool;
@@ -56,14 +57,12 @@ class MySqlConsumerProgressStore implements ConsumerProgressStore {
     database,
     tableNames
   }: MySqlConsumerProgressStoreOptions): Promise<MySqlConsumerProgressStore> {
-    const pool = createPool({
-      host: hostName,
+    const pool = createPoolWithDefaults({
+      hostName,
       port,
-      user: userName,
+      userName,
       password,
-      database,
-      connectTimeout: 0,
-      multipleStatements: true
+      database
     });
 
     pool.on('connection', (connection: PoolConnection): void => {

--- a/lib/stores/consumerProgressStore/MySql/MySqlConsumerProgressStore.ts
+++ b/lib/stores/consumerProgressStore/MySql/MySqlConsumerProgressStore.ts
@@ -1,6 +1,6 @@
 import { AggregateIdentifier } from '../../../common/elements/AggregateIdentifier';
 import { ConsumerProgressStore } from '../ConsumerProgressStore';
-import { createPoolWithDefaults } from '../../utils/mySql/createPool';
+import { createPoolWithDefaults } from '../../utils/mySql/createPoolWithDefaults';
 import { errors } from '../../../common/errors';
 import { getHash } from '../../../common/utils/crypto/getHash';
 import { IsReplaying } from '../IsReplaying';

--- a/lib/stores/domainEventStore/MySql/MySqlDomainEventStore.ts
+++ b/lib/stores/domainEventStore/MySql/MySqlDomainEventStore.ts
@@ -1,5 +1,5 @@
 import { AggregateIdentifier } from '../../../common/elements/AggregateIdentifier';
-import { createPoolWithDefaults } from '../../utils/mySql/createPool';
+import { createPoolWithDefaults } from '../../utils/mySql/createPoolWithDefaults';
 import { DomainEvent } from '../../../common/elements/DomainEvent';
 import { DomainEventData } from '../../../common/elements/DomainEventData';
 import { DomainEventStore } from '../DomainEventStore';

--- a/lib/stores/domainEventStore/MySql/MySqlDomainEventStore.ts
+++ b/lib/stores/domainEventStore/MySql/MySqlDomainEventStore.ts
@@ -1,4 +1,5 @@
 import { AggregateIdentifier } from '../../../common/elements/AggregateIdentifier';
+import { createPoolWithDefaults } from '../../utils/mySql/createPool';
 import { DomainEvent } from '../../../common/elements/DomainEvent';
 import { DomainEventData } from '../../../common/elements/DomainEventData';
 import { DomainEventStore } from '../DomainEventStore';
@@ -9,7 +10,7 @@ import { runQuery } from '../../utils/mySql/runQuery';
 import { Snapshot } from '../Snapshot';
 import { State } from '../../../common/elements/State';
 import { TableNames } from './TableNames';
-import { createPool, MysqlError, Pool, PoolConnection } from 'mysql';
+import { MysqlError, Pool, PoolConnection } from 'mysql';
 import { PassThrough, Readable } from 'stream';
 
 class MySqlDomainEventStore implements DomainEventStore {
@@ -59,14 +60,12 @@ class MySqlDomainEventStore implements DomainEventStore {
     database,
     tableNames
   }: MySqlDomainEventStoreOptions): Promise<MySqlDomainEventStore> {
-    const pool = createPool({
-      host: hostName,
+    const pool = createPoolWithDefaults({
+      hostName,
       port,
-      user: userName,
+      userName,
       password,
-      database,
-      connectTimeout: 0,
-      multipleStatements: true
+      database
     });
 
     pool.on('connection', (connection): void => {

--- a/lib/stores/lockStore/MySql/MySqlLockStore.ts
+++ b/lib/stores/lockStore/MySql/MySqlLockStore.ts
@@ -1,4 +1,4 @@
-import { createPoolWithDefaults } from '../../utils/mySql/createPool';
+import { createPoolWithDefaults } from '../../utils/mySql/createPoolWithDefaults';
 import { errors } from '../../../common/errors';
 import { getHash } from '../../../common/utils/crypto/getHash';
 import { LockStore } from '../LockStore';

--- a/lib/stores/lockStore/MySql/MySqlLockStore.ts
+++ b/lib/stores/lockStore/MySql/MySqlLockStore.ts
@@ -1,3 +1,4 @@
+import { createPoolWithDefaults } from '../../utils/mySql/createPool';
 import { errors } from '../../../common/errors';
 import { getHash } from '../../../common/utils/crypto/getHash';
 import { LockStore } from '../LockStore';
@@ -5,7 +6,7 @@ import { MySqlLockStoreOptions } from './MySqlLockStoreOptions';
 import { retry } from 'retry-ignore-abort';
 import { runQuery } from '../../utils/mySql/runQuery';
 import { TableNames } from './TableNames';
-import { createPool, MysqlError, Pool, PoolConnection } from 'mysql';
+import { MysqlError, Pool, PoolConnection } from 'mysql';
 
 class MySqlLockStore implements LockStore {
   protected pool: Pool;
@@ -53,14 +54,12 @@ class MySqlLockStore implements LockStore {
     database,
     tableNames
   }: MySqlLockStoreOptions): Promise<MySqlLockStore> {
-    const pool = createPool({
-      host: hostName,
+    const pool = createPoolWithDefaults({
+      hostName,
       port,
-      user: userName,
+      userName,
       password,
-      database,
-      connectTimeout: 0,
-      multipleStatements: true
+      database
     });
 
     pool.on('connection', (connection: PoolConnection): void => {

--- a/lib/stores/priorityQueueStore/MySql/MySqlPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/MySql/MySqlPriorityQueueStore.ts
@@ -1,3 +1,4 @@
+import { createPoolWithDefaults } from '../../utils/mySql/createPool';
 import { DoesIdentifierMatchItem } from '../DoesIdentifierMatchItem';
 import { errors } from '../../../common/errors';
 import { getIndexOfLeftChild } from '../shared/getIndexOfLeftChild';
@@ -13,7 +14,7 @@ import { runQuery } from '../../utils/mySql/runQuery';
 import { TableNames } from './TableNames';
 import { v4 } from 'uuid';
 import { withTransaction } from '../../utils/mySql/withTransaction';
-import { createPool, MysqlError, Pool, PoolConnection } from 'mysql';
+import { MysqlError, Pool, PoolConnection } from 'mysql';
 
 class MySqlPriorityQueueStore<TItem extends object, TItemIdentifier> implements PriorityQueueStore<TItem, TItemIdentifier> {
   protected tableNames: TableNames;
@@ -85,14 +86,12 @@ class MySqlPriorityQueueStore<TItem extends object, TItemIdentifier> implements 
       tableNames
     }: MySqlPriorityQueueStoreOptions<TCreateItem, TCreateItemIdentifier>
   ): Promise<MySqlPriorityQueueStore<TCreateItem, TCreateItemIdentifier>> {
-    const pool = createPool({
-      host: hostName,
+    const pool = createPoolWithDefaults({
+      hostName,
       port,
-      user: userName,
+      userName,
       password,
-      database,
-      connectTimeout: 0,
-      multipleStatements: true
+      database
     });
 
     pool.on('connection', (connection: PoolConnection): void => {

--- a/lib/stores/priorityQueueStore/MySql/MySqlPriorityQueueStore.ts
+++ b/lib/stores/priorityQueueStore/MySql/MySqlPriorityQueueStore.ts
@@ -1,4 +1,4 @@
-import { createPoolWithDefaults } from '../../utils/mySql/createPool';
+import { createPoolWithDefaults } from '../../utils/mySql/createPoolWithDefaults';
 import { DoesIdentifierMatchItem } from '../DoesIdentifierMatchItem';
 import { errors } from '../../../common/errors';
 import { getIndexOfLeftChild } from '../shared/getIndexOfLeftChild';

--- a/lib/stores/utils/mySql/createPoolWithDefaults.ts
+++ b/lib/stores/utils/mySql/createPoolWithDefaults.ts
@@ -1,0 +1,30 @@
+import { createPool as mySqlCreatePool, Pool } from 'mysql';
+
+const createPoolWithDefaults = function ({
+  hostName,
+  port,
+  userName,
+  password,
+  database
+}: {
+  hostName: string;
+  port: number;
+  userName: string;
+  password: string;
+  database: string;
+}): Pool {
+  return mySqlCreatePool({
+    host: hostName,
+    port,
+    user: userName,
+    password,
+    database,
+    connectTimeout: 0,
+    multipleStatements: true,
+    charset: 'utf8mb4'
+  });
+};
+
+export {
+  createPoolWithDefaults
+};

--- a/test/integration/stores/priorityQueueStore/getTestsFor.ts
+++ b/test/integration/stores/priorityQueueStore/getTestsFor.ts
@@ -43,6 +43,15 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
         name: 'execute',
         data: { strategy: 'succeed' },
         metadata: { timestamp: Date.now() + 1 }
+      }),
+      emojiCommand: buildCommandWithMetadata({
+        aggregateIdentifier: {
+          context: { name: 'sampleContext' },
+          aggregate: { name: 'sampleAggregate', id: firstAggregateId }
+        },
+        name: 'execute',
+        data: { strategy: 'succeed', dingus: '🐵 🙈 🙉 🙊' },
+        metadata: { timestamp: Date.now() + 4 }
       })
     },
     secondAggregate: {
@@ -107,6 +116,16 @@ const getTestsFor = function ({ createPriorityQueueStore }: {
           item: commands.firstAggregate.firstCommand,
           discriminator: commands.firstAggregate.firstCommand.aggregateIdentifier.aggregate.id,
           priority: commands.firstAggregate.firstCommand.metadata.timestamp
+        });
+      }).is.not.throwingAsync();
+    });
+
+    test('enqueues a command with emoji in it.', async (): Promise<void> => {
+      await assert.that(async (): Promise<void> => {
+        await priorityQueueStore.enqueue({
+          item: commands.firstAggregate.emojiCommand,
+          discriminator: commands.firstAggregate.emojiCommand.aggregateIdentifier.aggregate.id,
+          priority: commands.firstAggregate.emojiCommand.metadata.timestamp
         });
       }).is.not.throwingAsync();
     });


### PR DESCRIPTION
@yeldiRium, @dotKuro and I noticed that our MariaDB stores couldn't handle emoji properly. We've determined that this is because, although the tables are configured properly, we forgot to set the connection to `utf8mb4` also. We've fixed this, added a regression test and also simplified our use of `createPool` by wrapping the method. This way, we can't forget to set the appropriate default options.