### PR TITLE
feat: add algorithm property to identity provider

### DIFF
--- a/lib/clis/wolkenkit/dev/DevOptions.ts
+++ b/lib/clis/wolkenkit/dev/DevOptions.ts
@@ -7,5 +7,6 @@ export interface DevOptions extends RootOptions {
   'health-socket'?: string;
   'identity-provider-issuer'?: string;
   'identity-provider-certificate'?: string;
+  'identity-provider-algorithm'?: string;
   debug: boolean;
 }

--- a/lib/clis/wolkenkit/dev/devCommand.ts
+++ b/lib/clis/wolkenkit/dev/devCommand.ts
@@ -69,6 +69,14 @@ const devCommand = function (): Command<DevOptions> {
         isRequired: false
       },
       {
+        name: 'identity-provider-algorithm',
+        alias: 'a',
+        description: 'set an identity provider algorithm',
+        parameterName: 'algorithm',
+        type: 'string',
+        isRequired: false
+      },
+      {
         name: 'debug',
         alias: 'd',
         description: 'enable debug mode',
@@ -86,6 +94,7 @@ const devCommand = function (): Command<DevOptions> {
       'health-socket': healthSocket,
       'identity-provider-issuer': identityProviderIssuer,
       'identity-provider-certificate': identityProviderCertificate,
+      'identity-provider-algorithm': identityProviderAlgorithm,
       debug
     }}): Promise<void> {
       buntstift.configure(
@@ -122,7 +131,8 @@ const devCommand = function (): Command<DevOptions> {
         if (identityProviderIssuer && identityProviderCertificate) {
           identityProviders.push({
             issuer: identityProviderIssuer,
-            certificate: getAbsolutePath({ path: identityProviderCertificate, cwd: process.cwd() })
+            certificate: getAbsolutePath({ path: identityProviderCertificate, cwd: process.cwd() }),
+            algorithm: identityProviderAlgorithm
           });
         }
 


### PR DESCRIPTION
in order we add algorithm to [limes](https://github.com/thenativeweb/limes/pull/430) we can configure it per CLI, too.